### PR TITLE
Better genome download

### DIFF
--- a/bin/genome_download.R
+++ b/bin/genome_download.R
@@ -8,7 +8,7 @@ species1 <- gsub("_", " ", species)
 print("GENOME DOWNLOAD: Localtion for genome downloads:")
 print(file.path(wd, "results", "downloaded_genomes"))
 cat("\n\n")
-delay <- 1 # delay in seconds to prevent hitting the NCBI API access limit
+delay <- 2 # delay in seconds to prevent hitting the NCBI API access limit
 all_species <- unlist(strsplit(species, ","))
 
 successful <- c()
@@ -52,16 +52,22 @@ if (grepl("Unzipping downloaded file", my_message, fixed=T)) {
          print(paste("GENOME DOWNLOAD: Download for ", sp, " failed", sep=""))
          species_data[nrow(species_data)+1, ] <<- c(sp_name,"not_downloaded", "failed")
          failed <<- c(sp_name, failed)
+         print("GENOME DOWNLOAD: Message from biomartr:")
+         print(my_message)
          return
        } else if (!file.exists(file.path(wd, "results","downloaded_genomes",paste(sp_sub,"_genomic_genbank.fna",sep="")))){
          print(paste("GENOME DOWNLOAD: It seems no assembly for ", sp, " exists.", sep=""))
          species_data[nrow(species_data)+1, ] <<- c(sp_name,"not_downloaded", "failed")
          failed <<- c(sp_name, failed)
+         print("GENOME DOWNLOAD: Message from biomartr:")
+         print(my_message)
          return
        } else {
          print(paste("GENOME DOWNLOAD: An unknown error occurred during genome download for ", sp, sep=""))
          species_data[nrow(species_data)+1, ] <<- c(sp_name,"not_downloaded", "failed")
          failed <<- c(sp_name, failed)
+         print("GENOME DOWNLOAD: Message from biomartr:")
+         print(my_message)
          return
        }
 }
@@ -129,7 +135,7 @@ for (sp in all_species) {
               }
               mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
               my_message <- paste(mess$messages, collapse="\n")
-              parse_download_message(my_message, sp_subbed, sp)
+              parse_download_message(my_message, accession, sp)
               next
            }
            else {
@@ -140,7 +146,7 @@ for (sp in all_species) {
               }
               mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
               my_message <- paste(mess$messages, collapse="\n")
-              parse_download_message(my_message, sp_subbed, sp)
+              parse_download_message(my_message, accession, sp)
               next
            }  
         } else { # if there are multiple taxids proceed here
@@ -172,7 +178,7 @@ for (sp in all_species) {
                      }
                      mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
                      my_message <- paste(mess$messages, collapse="\n")
-                     parse_download_message(my_message, sp_subbed, sp)
+                     parse_download_message(my_message, accession, sp)
                      break
                   } else {
                      print("GENOME DOWNLOAD: Will download genome latest genome.")
@@ -182,7 +188,7 @@ for (sp in all_species) {
                      }
                      mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
                      my_message <- paste(mess$messages, collapse="\n")
-                     parse_download_message(my_message, sp_subbed, sp)
+                     parse_download_message(my_message, accession, sp)
                      break
                   }
                }

--- a/bin/genome_download.R
+++ b/bin/genome_download.R
@@ -127,21 +127,21 @@ for (sp in all_species) {
                      mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
                      my_message <- paste(mess$messages, collapse="\n")
                      parse_download_message(my_message, accession, sp)  
-                     next
+                     break 
                   } else if (is.na(genome_data2[genome_data2$refseq_category=="representative genome",]$assembly_accession[1]) == FALSE) {
                      print("GENOME DOWNLOAD: Representative genome found. Will download genome.")
                      accession <- genome_data2[genome_data2$refseq_category=="representative genome",]$assembly_accession[1] 
                      mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
                      my_message <- paste(mess$messages, collapse="\n")
                      parse_download_message(my_message, sp_subbed, sp)
-                     next
+                     break
                   } else {
                      print("GENOME DOWNLOAD: Will download genome latest genome.")
                      accession <- genome_data2$assembly_accession[length(genome_data2$seq_rel_date)][1]
                      mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
                      my_message <- paste(mess$messages, collapse="\n")
                      parse_download_message(my_message, sp_subbed, sp)
-                     next
+                     break
                   }
                }
 	  }

--- a/bin/genome_download.R
+++ b/bin/genome_download.R
@@ -1,13 +1,20 @@
 library(biomartr)
 library(data.table)
-
+library(taxize)
 args = commandArgs(trailingOnly=TRUE)
 species <- args[1]
 wd <- args[2]
 species1 <- gsub("_", " ", species)
+print("GENOME DOWNLOAD: Localtion for genome downloads:")
 print(file.path(wd, "results", "downloaded_genomes"))
+cat("\n\n")
 
 all_species <- unlist(strsplit(species, ","))
+
+successful <- c()
+failed <- c()
+warnings <- c()
+species_data <- data.frame(species=character(0), assembly= character(0), status= character(0), stringsAsFactors = F)
 
 messagereader <- function (fun, ...) { # this function will capture the output from the genome download function
   a <- textConnection("me", "w", local=TRUE) # create a text connection, capturing all text. the first variable (me) will be containing the messages captured
@@ -15,62 +22,132 @@ messagereader <- function (fun, ...) { # this function will capture the output f
   res <- tryCatch (
     expr = {
       fun(...) # evaluate the genome download call
-      message("Species download finished")
+      message("MESSAGE READER: Species download finished")
     },
     error = function(cond){
-      message("An error occurred during download!") # message when an error occurs
+      message("MESSAGE READER: An error occurred during download!") # message when an error occurs
       return(cond)
     },
     finally = {
-      message("trycatch done")
+      message("MESSAGE READER: trycatch done")
     }
   )
   sink(type="message")
   close(a)
   list(res, messages = me)
 }
-successful <- c()
-failed <- c()
-warnings <- c()
-species_data <- data.frame(species=character(0), assembly= character(0), status= character(0), stringsAsFactors = F)
+
+parse_download_message <- function(my_message, sp, sp_name) { # this function parses the download message from biomartr and decides what to do with it (successful/failed/error)
+sp_sub <- gsub(" ", "_", sp)
+sp_name <- gsub(" ", "_", sp_name)
+#print(sp_sub)
+#print(sp)
+if (grepl("Unzipping downloaded file", my_message, fixed=T)) {
+         print(paste("GENOME DOWNLOAD: Download for ", sp, "  was successfull", sep=""))
+         path <- file.path(wd, "results","downloaded_genomes",paste(sp_sub,"_genomic_genbank.fna",sep=""))
+         species_data[nrow(species_data)+1, ] <<- c(sp_name, path, "successful")
+         successful <<- c(sp_name, successful)
+         return
+       } else if (grepl("no genome file could be found", my_message, fixed=T) == TRUE) {
+         print(paste("GENOME DOWNLOAD: Download for ", sp, "failed", sep=""))
+         species_data[nrow(species_data)+1, ] <<- c(sp_name,"not_downloaded", "failed")
+         failed <<- c(sp_name, failed)
+         return
+       } else if (!file.exists(file.path(wd, "results","downloaded_genomes",paste(sp_sub,"_genomic_genbank.fna",sep="")))){
+         print(paste("GENOME DOWNLOAD: It seems no assembly for ", sp, "  exists.", sep=""))
+         species_data[nrow(species_data)+1, ] <<- c(sp_name,"not_downloaded", "failed")
+         failed <<- c(sp_name, failed)
+         return
+       } else {
+         print(paste("GENOME DOWNLOAD: An unknown error occurred during genome download for ", sp, sep=""))
+         species_data[nrow(species_data)+1, ] <<- c(sp_name,"not_downloaded", "failed")
+         failed <<- c(sp_name, failed)
+         return
+       }
+}
+
+get_genome_id_for_download <- function(sp) {
+
+}
+
+
 
 for (sp in all_species) {
+  print(paste("----------------------- ",sp," ----------------------- ", sep=""))
+  # first check if genome was already downloaded. In this case skip download.
   path <- file.path(wd,"results","downloaded_genomes",paste(sp,"_genomic_genbank.fna",sep=""))
   if (file.exists(path)) {
-	print(sp)
-	print("File exists, will skip")
+	print(paste("GENOME DOWNLOAD: File exists for ", sp, ". Will skip this species.", sep=""))
+        cat("\n\n")
 	successful <- c(sp, successful)
 	species_data[nrow(species_data)+1, ] <- c(sp, path, "successful")
 	next
 	}
-  sp <- gsub("_", " ", sp)
-  print(sp)
+  sp_subbed <- gsub("_", " ", sp)
   
-  mess <- messagereader(getGenome ,db="genbank", organism=sp, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
-  
-  my_message <- paste(mess$messages, collapse="\n")
-  print(my_message)
-  sp <- gsub(" ", "_", sp)
-  if (grepl("Unzipping downloaded file", my_message, fixed=T)) {
-      path <- file.path(wd, "results","downloaded_genomes",paste(sp,"_genomic_genbank.fna",sep=""))
-      species_data[nrow(species_data)+1, ] <- c(sp, path, "successful")
-      successful <- c(sp, successful)
-      next
-    } else if (grepl("no genome file could be found", my_message, fixed=T) == TRUE) {
-    species_data[nrow(species_data)+1, ] <- c(sp,"not_downloaded", "failed")
-    failed <- c(sp, failed)
-    next
-    } else if (!file.exists(file.path(wd, "results","downloaded_genomes",paste(sp,"_genomic_genbank.fna",sep="")))){
-	print(paste("It seems no assembly file exists for ", sp, sep=""))
-	species_data[nrow(species_data)+1, ] <- c(sp,"not_downloaded", "failed")
-	failed <- c(sp, failed)
-	next
-    } else {
-        print("Some other error occurred!")
-	species_data[nrow(species_data)+1, ] <- c(sp,"not_downloaded", "failed")
-	failed <- c(sp, failed)
+  #check if genome is available on NCBI
+  print("GENOME DOWNLOAD: Checking genome availibility...")
+  if (is.genome.available(db="genbank", organism=sp_subbed) == TRUE) {
+    # get information on available genomes:
+    genome_data <- is.genome.available(db="genbank", organism=sp_subbed, details=TRUE)
+    # check how many genomes:
+    if (nrow(genome_data)==1) {
+       print(paste("GENOME DOWNLOAD: Found a single genome for ", sp, ". Will download this genome now.",sep=""))
+       mess <- messagereader(getGenome ,db="genbank", organism=sp_subbed, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
+       my_message <- paste(mess$messages, collapse="\n")
+       parse_download_message(my_message, sp_subbed, sp)
+       #print(my_message)
+    } else { # if there are more than one genomes available for this taxon proceed here
+	if (length(unique(genome_data$taxid)) == 1) { #check if all assemblies have the same taxid
+           print("GENOME DOWNLOAD: All available genomes have the same taxid. Will search for available reference genome...")
+           if ("reference genome" %in% genome_data$refseq_category) { # reference genome found
+              print(paste("GENOME DOWNLOAD: Reference genome is available for ", sp, ". Will download this", sep=""))
+              # add code here
+           } else {
+              print(paste("GENOME DOWNLOAD: No genome is labeled as reference genome for ", sp, ". Will download the newest one.",sep=""))
+              # add code here
+           }  
+        } else { # if there are multiple taxids proceed here
+          print("GENOME DOWNLOAD: Multple taxids are present. Will try to resolve this...")
+          class <- classification(sp_subbed, db="ncbi") #this should also work with underscores in the name!
+          #print(class)
+          taxid <- class[[1]][class[[1]]$name == sp_subbed,]$id
+          #print(taxid)
+          for (x in 1:length(unique(genome_data$taxid))) {
+               print(toString(unique(genome_data$taxid)[x]))
+               if (taxid == toString(unique(genome_data$taxid)[x])) {
+                  print(paste("GENOME DOWNLOAD: Correct taxid for ",sp, " seems to be ", taxid,". Will search for reference genome now", sep=""))
+                  genome_data2 <- genome_data[genome_data$taxid==unique(genome_data$taxid)[x],]
+		  if (is.na(genome_data2[genome_data2$refseq_category=="reference genome",]$assembly_accession[1]) == FALSE) { # check if reference genome or representative genome
+                     print("GENOME DOWNLOAD: Reference genome found. Will download genome.")
+                     accession <- genome_data2[genome_data2$refseq_category=="reference genome",]$assembly_accession[1]
+                     mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
+                     my_message <- paste(mess$messages, collapse="\n")
+                     parse_download_message(my_message, accession, sp)  
+                     next
+                  } else if (is.na(genome_data2[genome_data2$refseq_category=="representative genome",]$assembly_accession[1]) == FALSE) {
+                     print("GENOME DOWNLOAD: Representative genome found. Will download genome.")
+                     accession <- genome_data2[genome_data2$refseq_category=="representative genome",]$assembly_accession[1] 
+                     mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
+                     my_message <- paste(mess$messages, collapse="\n")
+                     parse_download_message(my_message, sp_subbed, sp)
+                     next
+                  } else {
+                     print("GENOME DOWNLOAD: Will download genome latest genome.")
+                     accession <- genome_data2$assembly_accession[length(genome_data2$seq_rel_date)][1]
+                     mess <- messagereader(getGenome ,db="genbank", organism=accession, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
+                     my_message <- paste(mess$messages, collapse="\n")
+                     parse_download_message(my_message, sp_subbed, sp)
+                     next
+                  }
+               }
+	  }
+        }  
     }
-
+  } else {
+  print(paste("GENOME DOWNLOAD:Genome for ", sp, " is not available on NCBI genbank and could therefore not be downloaded.", sep=""))
+  }
+cat("\n\n")
 }
 #species_data$assembly[species_data$status=="bli"]
 #print(species_data)

--- a/bin/genome_download.R
+++ b/bin/genome_download.R
@@ -8,7 +8,7 @@ species1 <- gsub("_", " ", species)
 print("GENOME DOWNLOAD: Localtion for genome downloads:")
 print(file.path(wd, "results", "downloaded_genomes"))
 cat("\n\n")
-
+delay <- 2 # delay in seconds to prevent hitting the NCBI API access limit
 all_species <- unlist(strsplit(species, ","))
 
 successful <- c()
@@ -89,11 +89,14 @@ for (sp in all_species) {
   print("GENOME DOWNLOAD: Checking genome availibility...")
   if (is.genome.available(db="genbank", organism=sp_subbed) == TRUE) {
     # get information on available genomes:
+    Sys.sleep(delay) # to second delay to prevent hitting the NCBI API access limit
     genome_data <- is.genome.available(db="genbank", organism=sp_subbed, details=TRUE)
     # check how many genomes:
+    Sys.sleep(delay) # to second delay to prevent hitting the NCBI API access limit
     if (nrow(genome_data)==1) {
        print(paste("GENOME DOWNLOAD: Found a single genome for ", sp, ". Will download this genome now.",sep=""))
        mess <- messagereader(getGenome ,db="genbank", organism=sp_subbed, path=file.path(wd, "results","downloaded_genomes"), gunzip=T)
+       Sys.sleep(delay) # to second delay to prevent hitting the NCBI API access limit
        my_message <- paste(mess$messages, collapse="\n")
        parse_download_message(my_message, sp_subbed, sp)
        #print(my_message)

--- a/rules/setup.smk
+++ b/rules/setup.smk
@@ -9,6 +9,8 @@ rule download_genomes:
 		"results/statistics/benchmarks/setup/download_genomes.txt"
 	singularity:
 		"docker://reslp/biomartr:0.9.2_exp"
+	log:
+		"log/download_genomes.log"
 	params:
 		species = get_species_names,
                 wd = os.getcwd()
@@ -17,7 +19,7 @@ rule download_genomes:
 		if [[ ! -f results/statistics/runlog.txt ]]; then touch results/statistics/runlog.txt; fi
 		if [[ "{params.species}" != "" ]]; then
 			echo "(date) - Setup: Will download species now" >> results/statistics/runlog.txt
-			Rscript bin/genome_download.R {params.species} {params.wd}
+			Rscript bin/genome_download.R {params.species} {params.wd} 2>&1 | tee {log}
 		else
 			echo "(date) - Setup: Now species to download." >> results/statistics/runlog.txt
 		fi

--- a/rules/setup.smk
+++ b/rules/setup.smk
@@ -48,7 +48,7 @@ rule rename_assemblies:
 			if [[ -f {params.wd}/results/assemblies/"$spe".fna ]]; then
 				continue
 			else
-				link=$(tail -n +2 "{input.overview}" | grep "$spe" | awk -F',' '{{print $2}}')
+				link=$(tail -n +2 "{input.overview}" | grep "^$spe," | awk -F',' '{{print $2}}')
 				if [[ ! -f "$link" ]]; then
 					echo "$spe" >> {output.statistics} 
 					continue


### PR DESCRIPTION
These changes introduce a more refined genome download functionality. It takes into account several edge cases when interacting with the NCBI API. 
If available it should now prefer reference genomes over representative genomes. If these are not available the latest genome will be downloaded. In case of several available genomes, it is checked if the taxid is correct as well. This is necessary because it can happen that under a species name also other genomes are deposited (eg. Wolbachia endosymbiont genomes for insects...).
The output of genome download is now also more verbose.