### PR TITLE
Add improved filtering of busco results and alignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,22 @@ Tree inference:
 $ git clone https://github.com/reslp/smsi-phylogenomics.git
 $ cd smsi-phylogenomics
 $ ./phylociraptor
-Welcome to phylociraptor. The rapid pyhlogenomic tree calculator pipeline.
+Welcome to phylociraptor. The rapid phylogenomic tree calculator pipeline. Git commit: 70abfa0
 
 Usage: ./phylociraptor [-v] [-t <submission_system>] [-c <cluster_config_file>] [-s <snakemke_args>] [-m <mode>]
 
 Options:
-  -t <submission_system> Specify available submission system. Options: sge, slurm, serial (no submission system). Default: Automatic detection.
-  -c <cluster_config_file> Path to cluster config file in YAML format (mandatory). 
+  -t <submission_system> Specify available submission system. Options: sge, slurm, torque, serial (no submission system).
+  -c <cluster_config_file> Path to cluster config file in YAML format (mandatory).
   -s <snakemake_args> Additional arguments passed on to the snakemake command (optional). snakemake is run with --immediate-submit -pr --notemp --latency-wait 600 --use-singularity --jobs 1001 by default.
   -i "<singularity_args>" Additional arguments passed on to singularity (optional). Singularity is run with -B /tmp:/usertmp by default.
-  -m <mode> Specify runmode, separated by comma. Options: busco, align, model, tree.
+  -m <mode> Specify runmode, separated by comma. Options: orthology, filter-orthology, align, filter-align, model, tree, speciestree
 
-  --add-genomes will check for and add  additional genomes (in case they were added to the config files).
+  --add-genomes will check for and add additional genomes (in case they were added to the config files).
   --dry Invokes a dry-run. Corresponds to: snakemake -n
-  --report This flag will create an overview report about the BUSCO runs. It only works after -m busco has been run
-  --setup This flag will download the genomes and prepare the pipeline to run.
+  --report This creates an overview report of the run.
+  --setup Will download the genomes and prepare the pipeline to run.
   --remove Resets the pipeline. Will delete all results, logs and checkpoints.
-
 ```
 
 2. Create a conda environment with snakemake:
@@ -136,16 +135,28 @@ The basis of this file can be a CSV file directly downloaded from the [NCBI Geno
 $ ./phylociraptor --setup
 ```
 
-2. Run BUSCO for all the genomes:
+2. Identify orthologous genes for all the genomes:
 
 ```
-$ ./phylociraptor -t sge -c data/cluster_config-sauron.yaml -m busco
+$ ./phylociraptor -t sge -c data/cluster_config-sauron.yaml -m orthology
 ```
 
-3. Create alignments and trim them:
+3. Filter orthologs using according to settings in the `config.yaml` file:
+
+```
+$ ./phylociraptor -t sge -c data/cluster_config-sauron.yaml -m filter-orthology
+```
+
+4. Create alignments and trim them:
 
 ```
 $ ./phylociraptor -t sge -c data/cluster_config-sauron.yaml -m align
+```
+
+5. Filter alignments according to settings in the `config.yaml`file:
+
+```
+$ ./phylociraptor -t sge -c data/cluster_config-sauron.yaml -m filter-align
 ```
 
 Optionally you can run extensive model testing for individual alignments. This is done using iqtree. In case you run this step, the next step will use these models. Otherwise phylociraptor will use models specified in the config file.
@@ -154,18 +165,19 @@ Optionally you can run extensive model testing for individual alignments. This i
 $ ./phylociraptor -t sge -c data/cluster_config-sauron.yaml -m model
 ```
 
-4. Reconstruct a phylogeny:
+6. Reconstruct phylogenies:
 
 ```
+$ ./phylociraptor -t sge -c data/cluster_config-sauron.yaml -m njtree
 $ ./phylociraptor -t sge -c data/cluster_config-sauron.yaml -m tree
+$ ./phylociraptor -t sge -c data/cluster_config-sauron.yaml -m speciestree
 ```
 
-5. Create a report of the run:
+7. Create a report of the run:
 
 ```
 $ ./phylociraptor --report
 ```
-
 
 After this step, your results directory should look like this:
 
@@ -187,3 +199,5 @@ Is done in a Docker container which has conda, snakemake and singularity install
 ```
 docker run --rm -it --privileged -v $(pwd):/data reslp/smsi_ubuntu:3.4.1
 ```
+
+

--- a/Snakefile
+++ b/Snakefile
@@ -47,7 +47,7 @@ rule all:
 		#"results/checkpoints/iqtree_gene_trees.done",
 		#"results/checkpoints/astral_species_tree.done"
 		".phylogenomics_setup.done",
-		"checkpoints/part1.done",
+		"checkpoints/orthology.done",
 		"checkpoints/part2.done",
 		"checkpoints/part3.done"
 rule setup:
@@ -81,18 +81,19 @@ rule add_genomes:
 		touch {output}
 		"""
 
-rule part1:
+rule orthology:
 	input:	
-                expand("results/checkpoints/busco/busco_{species}.done", species=glob_wildcards("results/assemblies/{species}.fna").species),
+               	# expand("results/checkpoints/busco/busco_{species}.done", species=glob_wildcards("results/assemblies/{species}.fna").species),
+		"results/checkpoints/busco.done",
 		"results/checkpoints/extract_busco_table.done",
-		"results/checkpoints/create_sequence_files.done",
-		"results/checkpoints/remove_duplicated_sequence_files.done"
+		#"results/checkpoints/create_sequence_files.done",
+		#"results/checkpoints/remove_duplicated_sequence_files.done"
 	output:
-		"checkpoints/part1.done"
+		"checkpoints/orthology.done"
 	shell:
 		"""
 		touch {output}
-		echo "$(date) - Pipeline part 1 (busco) done." >> results/statistics/runlog.txt
+		echo "$(date) - Pipeline part 1 (orthology) done." >> results/statistics/runlog.txt
 		"""
 rule part2:
 	input:
@@ -141,7 +142,7 @@ rule speciestree:
 		"""
 
 include: "rules/setup.smk"
-include: "rules/busco.smk"
+include: "rules/orthology.smk"
 include: "rules/align_trim.smk"
 include: "rules/model.smk"
 include: "rules/tree.smk"

--- a/Snakefile
+++ b/Snakefile
@@ -95,6 +95,18 @@ rule orthology:
 		touch {output}
 		echo "$(date) - Pipeline part 1 (orthology) done." >> results/statistics/runlog.txt
 		"""
+
+rule filter_orthology:
+	input:
+		"results/checkpoints/create_sequence_files.done",
+		"results/checkpoints/remove_duplicated_sequence_files.done"
+	output:
+		"checkpoints/filter_orthology.done"
+	shell:
+		"""
+		echo "$(date) - Pipeline part filter-orthology done." >> results/statistics/runlog.txt
+		touch {output}
+		"""
 rule part2:
 	input:
 		"results/checkpoints/get_all_trimmed_files.done",
@@ -143,6 +155,7 @@ rule speciestree:
 
 include: "rules/setup.smk"
 include: "rules/orthology.smk"
+include: "rules/filter-orthology.smk"
 include: "rules/align_trim.smk"
 include: "rules/model.smk"
 include: "rules/tree.smk"

--- a/Snakefile
+++ b/Snakefile
@@ -107,17 +107,30 @@ rule filter_orthology:
 		echo "$(date) - Pipeline part filter-orthology done." >> results/statistics/runlog.txt
 		touch {output}
 		"""
-rule part2:
+rule align_trim:
 	input:
-		"results/checkpoints/get_all_trimmed_files.done",
+		"results/checkpoints/aggregate_align.done",
 		"results/statistics/statistics_alignments.txt"
 	output:
-		"checkpoints/part2.done"
+		"checkpoints/align_trim.done"
 	shell:
 		"""
 		touch {output}	
 		echo "$(date) - Pipeline part 2 (align) done." >> results/statistics/runlog.txt
 		"""
+
+rule part_filter_align:
+	input:
+		"results/checkpoints/filter_alignments.done",
+		"results/statistics/statistics_filtered.txt"	
+	output:
+		"checkpoints/filter_align.done"
+	shell:
+		"""
+		echo "$(date) - Pipeline part filter_align done." >> results/statistics/runlog.txt
+		touch {output}
+		"""
+
 
 rule part_modeltest:
 	input:
@@ -157,6 +170,7 @@ include: "rules/setup.smk"
 include: "rules/orthology.smk"
 include: "rules/filter-orthology.smk"
 include: "rules/align_trim.smk"
+include: "rules/filter-align_trim.smk"
 include: "rules/model.smk"
 include: "rules/tree.smk"
 include: "rules/speciestree.smk"

--- a/bin/extract_busco_table.py
+++ b/bin/extract_busco_table.py
@@ -12,6 +12,7 @@ if sys.version_info[0] < 3:
 pars = argparse.ArgumentParser(prog="get_busco_table.py", description = """This script will get all busco3 hmms and look in the busco results all specified genomes for the presence of the files""", epilog = """written by Philipp Resl""")
 pars.add_argument('--hmm', dest="hmm_dir", required=True, help="Directory of the BUSCO hmms.")
 pars.add_argument('--busco_results', dest="busco_results", required=True, help="Results directory containing all BUSCO runs.")
+pars.add_argument('-o', dest="out", required=True, help="BUSCO table output file.")
 args=pars.parse_args()
 
 hmms = os.listdir(args.hmm_dir)
@@ -19,19 +20,21 @@ hmms = [hmm.strip(".hmm") for hmm in hmms]
 
 genomes = os.listdir(args.busco_results)
 
-string = "species\t"
-string += "\t".join(hmms)
-string += "\tpercent_complete" 
-print(string)
-ones = 0
-zeros = 0
+outfile = open(args.out, "w")
+header = "species\t"
+header += "\t".join(hmms)
+header += "\tpercent_complete" 
+print(header, file= outfile)
 for species in genomes:
+	ones = 0
+	zeros = 0
 	outstring = species
 	print("Extracting HMMs for", species, file=sys.stderr)
 	try:
+		buscos = os.listdir(args.busco_results + species + "/run_busco/single_copy_busco_sequences/")
+		buscos = [busco.strip(".faa") for busco in buscos]
 		for hmm in hmms:
-			buscos = os.listdir(args.busco_results + species + "/run_busco/single_copy_busco_sequences/")
-			if hmm+".faa" in buscos:
+			if hmm in buscos:
 				outstring += "\t"
 				outstring += "1"
 				ones +=1
@@ -42,8 +45,9 @@ for species in genomes:
 		percent = ones / (ones+zeros)
 		outstring += "\t"
 		outstring += str(percent)
-		print(outstring)
+		print(outstring, file=outfile)
 	except:
 		out = species + " not found. Skipped.\n"
 		print(out, file=sys.stderr)
 		continue
+outfile.close()

--- a/bin/filter_alignments.py
+++ b/bin/filter_alignments.py
@@ -13,25 +13,43 @@ pars = argparse.ArgumentParser(prog="filter_alignments.py", description = """Thi
 pars.add_argument('--alignments', dest="align", required=True, help="alignment files")
 pars.add_argument('--outdir', dest="outdir", required=True, help="output directory")
 pars.add_argument('--per_sample', dest="perseq", action='store_true', help="if set, only samples with duplicated sequences will be removed. Else the whole alignment")
+pars.add_argument('--min-parsimony', dest="minpars", required=True, help="The minimum number of parsimony informative sites and alignment must have to be kept.")
+pars.add_argument('--statistics-file', dest="statfile", required=True, help="Statistics file which contains alignment information(incl. parsimony informative sites; this file needs to be created with concat)")
 args=pars.parse_args()
 
 algn_list = args.align.split(" ")
 
+stats_dict = {}
+with open(args.statfile, "r") as stats:
+	stats.readline()
+	for stat in stats:
+		stats_dict[stat.split("\t")[0]] = int(stat.split("\t")[5])	
 for al in algn_list:
+	if os.stat(al).st_size == 0:
+		print(os.path.basename(al), "\tEMPTY")
+		continue
+	if stats_dict[os.path.basename(al)] < int(args.minpars):
+		print(os.path.basename(al), "\tNOT_INFORMATIVE")
+		continue
+	
 	seqfile = open(al, "r")
 	sequences = []
 	for seq_record in SeqIO.parse(seqfile, "fasta"):
 		sequences.append(seq_record)
 	names_list = [seq.id for seq in sequences]
+	if len(names_list) < 3:
+		print(os.path.basename(al), "\tTOO_FEW_SEQUENCES")
+		continue
 	if len(names_list) == len(set(names_list)):
-		print("Create symlink: ", args.outdir+"/"+al.split("/")[-1])
+		print("Create symlink: ", args.outdir+"/"+al.split("/")[-1], file=sys.stderr)
 		os.symlink(al, args.outdir+"/"+al.split("/")[-1])
+		print(os.path.basename(al), "\tPASS")
 	else:
-		print("Warning: File %s contains duplicated sequence IDs!" % al)
+		print("Warning: File %s contains duplicated sequence IDs!" % al, file=sys.stderr)
 		if (args.perseq == True):	
-			print("Duplicated sequences will be removed and copy of file will be made.")
+			print("Duplicated sequences will be removed and copy of file will be made.", file=sys.stderr)
 			dups = [name for name in names_list if names_list.count(name)>1]
-			print("Warning: Will remove %d sequences" % len(dups))
+			print("Warning: Will remove %d sequences" % len(dups), file=sys.stderr)
 			dups = set(dups)
 			sequences = [sequence for sequence in sequences if sequence.id not in dups]
 			outfile = open(args.outdir+"/"+al.split("/")[-1], "w")
@@ -39,7 +57,9 @@ for al in algn_list:
 				print(">"+sequence.id, file=outfile)
 				print(sequence.seq, file=outfile)					
 			outfile.close()
+			print(os.path.basename(al), "\tREMOVE_DUPLICATED_SEQUENCES")
 		else:
-			print("Warning: %s file will be discarded" % al)	
+			print("Warning: %s file will be discarded" % al)
+			print(os.path.basename(al), "\tREMOVED")	
 
 

--- a/bin/report.Rmd
+++ b/bin/report.Rmd
@@ -19,7 +19,7 @@ library(stringr)
 library(data.table)
 #library(ggpubr)
 
-parsimony_cutoff <- 10
+parsimony_cutoff <- 3
 
 
 # function to convert seconds to better formated time:
@@ -43,11 +43,19 @@ dhms <- function(t){
 
 busco_overview_image <- ""
 
+# orthology statistics file:
 busco_overview_file <- "../results/busco_set/dataset.cfg"
 busco_summary_file <- "../results/statistics/busco_summary.txt"
+orthology_filtering_genomes_file <- "../results/statistics/orthology_filtering_genomes_statistics.txt"
+orthology_filtering_genes_file <- "../results/statistics/orthology_filtering_gene_statistics.txt"
+
+
+#  alignment statistics information
 alignment_statistics_file <- "../results/statistics/statistics_alignments.txt"
 trimmed_alignment_statistics_file <- "../results/statistics/statistics_trimmed.txt"
 filtered_alignment_statistics_file <- "../results/statistics/statistics_filtered.txt"
+filtered_gene_information_file <- "../results/statistics/alignment_filter_information.txt"
+
 align_trim_overview_statistics_file <- "../results/statistics/align_trim_overview_statistics.txt"
 
 downloaded_genomes_statistics_file <- "../results/statistics/downloaded_genomes_statistics.txt"
@@ -149,7 +157,7 @@ if (file.exists(downloaded_genomes_statistics_file))
 `r info`
 
 
-### BUSCO
+### Orthology
 
 ```{r, echo=FALSE}
 
@@ -174,8 +182,27 @@ if (file.exists(benchmarkfile_run_busco)) {
   busco_bench_df <- "not_found"
 }
 
-```
+if (file.exists(orthology_filtering_genomes_file)) {
+  ortho_filter_genomes <- read.table(orthology_filtering_genomes_file, sep="\t", header=F)
+  colnames(ortho_filter_genomes) <- c("sample", "status", "completeness", "cutoff")
+  failed_genomes <- ortho_filter_genomes$sample[ortho_filter_genomes$status == "FAILED"]
+  cutoff <- ortho_filter_genomes$cutoff[1]
+} else {
+  failed_genomes <- numeric()
+  cutoff <- numeric()
+}
+if (file.exists(orthology_filtering_genes_file)) {
+  ortho_filter_genes <- read.table(orthology_filtering_genes_file, sep="\t", header=F)
+  colnames(ortho_filter_genes) <- c("gene", "status", "nseqs", "cutoff")
+  failed_genes <- ortho_filter_genes$gene[ortho_filter_genes$status == "FAILED"]
+  cutoff_gene <- ortho_filter_genes$cutoff[1]
+} else {
+  failed_genes <- numeric()
+  cutoff_gene <- numeric()
+}
 
+```
+Orthologous genes were inferred using BUSCO.
 
 **Location of BUSCO results:** 
 
@@ -185,11 +212,19 @@ results/busco
 
 **Used BUSCO set:** `r busco_set`
 
-**Number of BUSCO genes:** `r nbuscos`
+**Total number of BUSCO genes in BUSCO set:** `r nbuscos`  
+**Number of BUSCO genes recovered in too few (`r cutoff_gene`) samples:** `r length(failed_genes)`  
+**BUSCO genes below threshold:**  
+`r failed_genes`
 
-**Runtime Statistics:**
+**Number of samples with single-copy BUSCO score below threshold (`r cutoff`):** `r length(failed_genomes)`  
+**Genomes below threshold:**  
+`r failed_genomes`
 
-|        Total (cumulative) runtime: `r if (busco_bench_df != "not_found") { dhms(sum(busco_bench_df$seconds)) }`
+**Runtime Statistics:**  
+
+|        Total (cumulative) runtime:
+|        `r if (busco_bench_df != "not_found") { dhms(sum(busco_bench_df$seconds)) }`
 
 ```{r, echo=F, message=F, warning=F, fig.width=8}
 if (busco_bench_df != "not_found") {
@@ -250,6 +285,7 @@ if (file.exists(busco_overview_image)) {
 results/alignments
 ```
 
+
 ```{r stats_alignments, echo=FALSE}
 if (file.exists(align_trim_overview_statistics_file) == TRUE) {
   ov <- read.table(align_trim_overview_statistics_file, sep="\t", header=F)
@@ -257,9 +293,11 @@ if (file.exists(align_trim_overview_statistics_file) == TRUE) {
   al_params <- ov[2,2]
   tr_method <- ov[3,2]
   tr_params <- ov[4,2]
+  parsimony_cutoff <- as.numeric(ov[5,2])
 } else {
   al_method <- "unknown (check if phylocraptor -m align has finished successfully)."
   al_params <- ""
+  parsimony_cutoff <- 0
 }
 if (file.exists(alignment_statistics_file) == TRUE) {
   data <- read.table(alignment_statistics_file, sep="\t", header=T)
@@ -269,9 +307,9 @@ if (file.exists(alignment_statistics_file) == TRUE) {
 }
 ```
 
-**Alignment method:** `r al_method` `r al_params`
-
-There are **`r length(few_npars)`** alignments with less than `r parsimony_cutoff` parsimony informative sites.
+**Alignment method:** `r al_method` `r al_params`  
+**Total number of alignments:** `r nrow(data)`  
+**Alignments with less than `r parsimony_cutoff` parsimony informative sites:** `r length(few_npars)`  
 
 
 ```{r stats_alignments2, echo=FALSE}
@@ -304,9 +342,11 @@ if (file.exists(align_trim_overview_statistics_file) == TRUE) {
   ov <- read.table(align_trim_overview_statistics_file, sep="\t", header=F)
   tr_method <- ov[3,2]
   tr_params <- ov[4,2]
+  parsimony_cutoff <- as.numeric(ov[5,2])
 } else {
   tr_method <- "unknown (check if phylocraptor -m align has finished successfully)."
   tr_params <- numeric()
+  parsimony_cutoff <- 0
 }
 
 if (file.exists(trimmed_alignment_statistics_file) == TRUE) {
@@ -317,13 +357,13 @@ if (file.exists(trimmed_alignment_statistics_file) == TRUE) {
 }
 ```
 
-**Trimming method:** `r tr_method` `r tr_params`
-
-There are **`r length(few_npars)`** trimmed alignments with less than `r parsimony_cutoff` parsimony informative sites.
+**Trimming method:** `r tr_method` `r tr_params`  
+**Total number of alignments after trimming:** `r nrow(data)`  
+**Alignments with less than `r parsimony_cutoff` parsimony informative sites:** `r length(few_npars)`  
 
 ```{r stats_trimmed2, echo=FALSE}
 if (file.exists(trimmed_alignment_statistics_file) == TRUE) {
-rows <- which(data$nparsimony < 10)
+rows <- which(data$nparsimony < parsimony_cutoff)
 #data$nparsimony <- cell_spec(data$nparsimony, color = ifelse(data$nparsimony < parsimony_cutoff, "red", "black"))
 #data$alignment <- cell_spec(data$alignment, color = ifelse(data$nparsimony[data$alignment] < parsimony_cutoff, "red", "black"))
 #print(rows)
@@ -348,6 +388,20 @@ if (file.exists(filtered_alignment_statistics_file) == TRUE) {
 } else {
   few_npars <- numeric()
 }
+if (file.exists(filtered_gene_information_file) == TRUE) {
+  data_filtered <- read.table(filtered_gene_information_file, sep="\t", header=F)
+  colnames(data_filtered) <- c("alignment", "status")
+  uninformative_alignments <- data_filtered$alignment[data_filtered$status == "NOT_INFORMATIVE"]
+  too_few_seqs_alignments <- data_filtered$alignment[data_filtered$status == "TOO_FEW_SEQUENCES"]
+  dup_seqs_removed <- data_filtered$alignment[data_filtered$status == "REMOVE_DUPLICATED_SEQUENCES"]
+  dup_align_removed <- data_filtered$alignment[data_filtered$status == "REMOVED"]
+} else {
+  uninformative_alignments <- numeric()
+  too_few_seqs_alignments <- numeric()
+  dup_seqs_removed <- numeric()
+  dup_align_removed <- numeric()
+}
+
 ```
 
 **Location of filtered alignment files:** 
@@ -355,7 +409,24 @@ if (file.exists(filtered_alignment_statistics_file) == TRUE) {
 results/filtered_alignments
 ```
 
-There are `r length(few_npars)` filtered alignments with less than `r parsimony_cutoff` parsimony informative sites.
+**Total number of alignments after filtering:** `r nrow(data)`  
+**Number of discarded alignments:** `r length(uninformative_alignments)+length(too_few_seqs_alignments)+length(dup_align_removed)`  
+
+**The following alignments were discarded:**  
+
+_Too few parsimony informative sites:_  
+`r if (length(uninformative_alignments) == 0){"none"}else{uninformative_alignments}`
+
+_Less then three sequences after trimming:_  
+`r if (length(too_few_seqs_alignments) == 0){"none"}else{too_few_seqs_alignments}`
+
+_Removed alignments due to duplicated sequences:_  
+`r if (length(dup_align_removed) == 0){"none"}else{dup_align_removed}`
+
+_Alignments with removed (duplicated) sequences:_  
+`r if (length(dup_seqs_removed)==0){"none"}else{dup_seqs_removed}`
+
+
 
 ```{r stats_filtered2, echo=FALSE}
 if (file.exists(filtered_alignment_statistics_file) == TRUE) {

--- a/data/cluster-config-SGE.yaml.template
+++ b/data/cluster-config-SGE.yaml.template
@@ -10,6 +10,8 @@ busco:
    N: BUSCO 
 orthology:
    N: ORTHOLOGY
+filter_orthology:
+   N: FILTORTH
 run_busco:
    N: rBUSCO
    h_vmem: 2G

--- a/data/cluster-config-SGE.yaml.template
+++ b/data/cluster-config-SGE.yaml.template
@@ -12,6 +12,16 @@ orthology:
    N: ORTHOLOGY
 filter_orthology:
    N: FILTORTH
+filter_alignments:
+   N: filtalgn
+part_filter_align:
+   N: FAL
+align_trim:
+   N: alntri
+filter_align:
+   N: FAL
+get_filter_statistics:
+   N: getfilstat
 run_busco:
    N: rBUSCO
    h_vmem: 2G

--- a/data/cluster-config-SGE.yaml.template
+++ b/data/cluster-config-SGE.yaml.template
@@ -8,6 +8,8 @@ __default__:
    pe: mpi1node # change this according your cluster configuration
 busco:
    N: BUSCO 
+orthology:
+   N: ORTHOLOGY
 run_busco:
    N: rBUSCO
    h_vmem: 2G

--- a/data/cluster-config-SLURM.yaml.template
+++ b/data/cluster-config-SLURM.yaml.template
@@ -11,6 +11,8 @@ __default__:
    error: $(pwd)/log/slurm-%j.err
 busco:
    J: BUSCO 
+orthology:
+   J: ORTHOLOGY
 run_busco:
    J: rBUSCO
    ntasks: 16
@@ -59,9 +61,6 @@ phylobayes:
    ntasks: 30
 merge_phylobayes_chains:
    J: merge_phylobayes
-   mem: 4G
-part1:
-   J: part1
    mem: 4G
 part2:
    J: part2

--- a/data/cluster-config-SLURM.yaml.template
+++ b/data/cluster-config-SLURM.yaml.template
@@ -15,6 +15,16 @@ orthology:
    J: ORTHOLOGY
 filter_orthology:
    J: FILTORTH
+filter_alignments:
+   J: filtalgn
+part_filter_align:
+   J: FAL
+align_trim:
+   J: alntri
+filter_align:
+   J: FAL
+get_filter_statistics:
+   J: getfilstat 
 run_busco:
    J: rBUSCO
    ntasks: 16

--- a/data/cluster-config-SLURM.yaml.template
+++ b/data/cluster-config-SLURM.yaml.template
@@ -13,6 +13,8 @@ busco:
    J: BUSCO 
 orthology:
    J: ORTHOLOGY
+filter_orthology:
+   J: FILTORTH
 run_busco:
    J: rBUSCO
    ntasks: 16

--- a/data/cluster-config-TORQUE.yaml.template
+++ b/data/cluster-config-TORQUE.yaml.template
@@ -11,6 +11,8 @@ busco:
    N: BUSCO 
 orthology:
    N: ORTHOLOGY
+filter_orthology:
+   N: FILTORTH
 run_busco:
    N: rBUSCO
    mem: 32gb

--- a/data/cluster-config-TORQUE.yaml.template
+++ b/data/cluster-config-TORQUE.yaml.template
@@ -9,6 +9,8 @@ __default__:
    walltime: "12:00:00"
 busco:
    N: BUSCO 
+orthology:
+   N: ORTHOLOGY
 run_busco:
    N: rBUSCO
    mem: 32gb

--- a/data/cluster-config-TORQUE.yaml.template
+++ b/data/cluster-config-TORQUE.yaml.template
@@ -13,6 +13,16 @@ orthology:
    N: ORTHOLOGY
 filter_orthology:
    N: FILTORTH
+filter_alignments:
+   N: filtalgn
+part_filter_align:
+   N: FAL
+align_trim:
+   N: alntri
+filter_align:
+   N: FAL
+get_filter_statistics:
+   N: getfilstat
 run_busco:
    N: rBUSCO
    mem: 32gb

--- a/data/config.yaml.template
+++ b/data/config.yaml.template
@@ -7,15 +7,21 @@ busco:
     augustus_species: fly
     additional_parameters: ""
 
-# Here different filtering options can be set for the busco sequence files:
-# dupseq: how occasionally found duplicated sequences should be handled: persample = for each busco filter out the samples with duplicated sequences. perfile = filter out complete busco sequence file.
-# cutoff: minimum proportion of busco completeness a species needs so that it is included in the analysis.
-# minsp: minimum number of species for which a busco was found so that it is included in the analysis.
+# Setting filtering options for orthology and alignments:
+# ---- Orthology results can be filtered based on two settings cutoff and minsp: ----
+# cutoff = the minimum proportion of single-copy BUSCO sequences a sample needs to have for it to be included in subsequent analysis. Default: 0.5 (50% single copy BUSCOs)
+# minsp = the minimum number of samples which need to have a specific BUSCO gene for the gene to be included in subsequent analysis. Default: 3 (at least three species need to have the gene)
+# ---- Trimmed alignments can be additionally filtered ----
+# dupseq = occasionally BUSCO will find more than one sequence for a single-copy BUSCO gene. With dupseq you can decide how this is handeled. dupseq="persample" for each busco filter out the samples with duplicated sequences. dubseq="perfile" filters out the BUSCO sequence file for that gene.
+# min_parsimony_sites = the minimum number of parsiomony informative sites a trimmed alignment needs to have for it to be included in tree calculation.
+
 filtering:
     dupseq: "persample"
     cutoff: 0.5
     minsp: 3
     seq_type: "aa"
+    min_parsimony_sites: 10
+
 # settings related to alignment and trimming
 alignment:
     method: mafft

--- a/phylociraptor
+++ b/phylociraptor
@@ -177,23 +177,23 @@ if [[ $RUNMODE == *"single"* ]]; then
 	fi
 fi
 # these if cases are still crude and do not cover all possible combinations!
-if [[ $RUNMODE == *"busco"* ]]; then
+if [[ $RUNMODE == "orthology" ]]; then
   if [[ ! -f ".phylogenomics_setup.done" ]]; then
 	echo "You must first run phylogenomics --setup to run the pipeline"
 	exit 0
   fi
-  echo "Runmode set to: busco. Will run first part of pipeline to generate BUSCO results.."
+  echo "Runmode set to: orthology. Will run BUSCO to identify orthologous genes."
   if [[ $CLUSTER == "slurm" ]]; then
           export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
           mkdir -p .conda_pkg_tmp
-          snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster '$(pwd)/bin/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS -r part1 $SM_ARGS $DRY
+          snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster '$(pwd)/bin/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS -r orthology $SM_ARGS $DRY
   	unset CONDA_PKGS_DIRS
   elif [[ $CLUSTER == "sge" ]]; then
-  	snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS -r part1 $SM_ARGS $DRY
+  	snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS -r orthology $SM_ARGS $DRY
   elif [[ $CLUSTER == "torque" ]]; then
-        snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS -r part1 $SM_ARGS $DRY
+        snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS -r orthology $SM_ARGS $DRY
   elif [[ $CLUSTER == "serial" ]]; then
-    snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" -pr --notemp $SM_ARGS -r part1 $DRY
+    snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" -pr --notemp $SM_ARGS -r orthology $DRY
   else
           echo "Submission system not recognized"
           exit 1

--- a/phylociraptor
+++ b/phylociraptor
@@ -236,13 +236,13 @@ if [[ $RUNMODE == "filter-orthology" ]]; then
   fi
 fi
 
-if [[ $RUNMODE == *"align"* ]]; then
+if [[ $RUNMODE == "align" ]]; then
   if [[ ! -f ".phylogenomics_setup.done" ]]; then
         echo "You must first run phylogenomics --setup to run the pipeline"
         exit 0
   fi
   if [[ ! -f "checkpoints/filter_orthology.done" ]]; then
-        echo "You must first phylogenomics -m busco to run this part of the pipeline"
+        echo "You must first phylogenomics -m filter-orthology to run this part of the pipeline"
         exit 0
   fi
   mkdir -p .usr_tmp
@@ -250,20 +250,55 @@ if [[ $RUNMODE == *"align"* ]]; then
   if [[ $CLUSTER == "slurm" ]]; then
           export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
           mkdir -p .conda_pkg_tmp
-          snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster '$(pwd)/bin/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS -r part2 $SM_ARGS $DRY
+          snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster '$(pwd)/bin/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS -r align_trim $SM_ARGS $DRY
         unset CONDA_PKGS_DIRS
   elif [[ $CLUSTER == "sge" ]]; then
-        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS -r part2 $SM_ARGS $DRY
+        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS -r align_trim $SM_ARGS $DRY
   elif [[ $CLUSTER == "torque" ]]; then
-        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS -r part2 $SM_ARGS $DRY
+        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS -r align_trim $SM_ARGS $DRY
   elif [[ $CLUSTER == "serial" ]]; then
-    snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" $STDSMARGS $SM_ARGS -r part2 $DRY
+    snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" $STDSMARGS $SM_ARGS -r align_trim $DRY
   else
           echo "Submission system not recognized"
           exit 1
   fi
 fi
 
+if [[ $RUNMODE == "filter-align" ]]; then
+  if [[ ! -f ".phylogenomics_setup.done" ]]; then
+        echo "You must first run phylogenomics --setup to run the pipeline"
+        exit 0
+  fi
+  if [[ ! -f "checkpoints/align_trim.done" ]]; then
+        echo "You must first phylogenomics -m align to run this part of the pipeline"
+        exit 0
+  fi
+  mkdir -p .usr_tmp
+  echo "Runmode set to: filter-align. Will filter alignments based ony settings in config file."
+  if [[ $DRY != "-n" ]]; then
+	echo "Will remove previous results..."
+	rm -fr results/filtered_alignments/*
+	rm -f results/checkpoints/aggregate_align.done
+	rm -f results/statistics/alignment_filter_information.txt
+	rm -f results/statistics/statistics_alignments.txt
+	rm -f checkpoints/filter_align.done
+  fi
+  if [[ $CLUSTER == "slurm" ]]; then
+          export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
+          mkdir -p .conda_pkg_tmp
+          snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster '$(pwd)/bin/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS -r part_filter_align $SM_ARGS $DRY
+        unset CONDA_PKGS_DIRS
+  elif [[ $CLUSTER == "sge" ]]; then
+        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS -r part_filter_align $SM_ARGS $DRY
+  elif [[ $CLUSTER == "torque" ]]; then
+        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS -r part_filter_align $SM_ARGS $DRY
+  elif [[ $CLUSTER == "serial" ]]; then
+    snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" $STDSMARGS $SM_ARGS -r part_filter_align $DRY
+  else
+          echo "Submission system not recognized"
+          exit 1
+  fi
+fi
 if [[ $RUNMODE == *"model"* ]]; then
   if [[ ! -f ".phylogenomics_setup.done" ]]; then
         echo "You must first run phylogenomics --setup to run the pipeline"

--- a/phylociraptor
+++ b/phylociraptor
@@ -361,7 +361,7 @@ if [[ $RUNMODE == "tree" ]]; then
         echo "You must first phylogenomics -m filter-orthology to run this part of the pipeline"
         exit 0
   fi
- if [[ ! -f "checkpoints/align.done" ]]; then
+ if [[ ! -f "checkpoints/align_trim.done" ]]; then
         echo "You must first phylogenomics -m align to run this part of the pipeline"
         exit 0
   fi
@@ -408,7 +408,7 @@ if [[ $RUNMODE == *"speciestree"* ]]; then
         echo "You must first phylogenomics -m filter-orthology to run this part of the pipeline"
         exit 0
   fi
- if [[ ! -f "checkpoints/align.done" ]]; then
+ if [[ ! -f "checkpoints/align_trim.done" ]]; then
         echo "You must first phylogenomics -m align to run this part of the pipeline"
         exit 0
   fi

--- a/phylociraptor
+++ b/phylociraptor
@@ -13,7 +13,7 @@ usage() {
         echo "  -c <cluster_config_file> Path to cluster config file in YAML format (mandatory). "
         echo "  -s <snakemake_args> Additional arguments passed on to the snakemake command (optional). snakemake is run with --immediate-submit -pr --notemp --latency-wait 600 --use-singularity --jobs 1001 by default."
         echo "  -i \"<singularity_args>\" Additional arguments passed on to singularity (optional). Singularity is run with -B /tmp:/usertmp by default."
-        echo "  -m <mode> Specify runmode, separated by comma. Options: busco, align, model, tree, speciestree"
+        echo "  -m <mode> Specify runmode, separated by comma. Options: orthology, filter-orthology, align, model, tree, speciestree"
 	echo
 	echo "  --add-genomes will check for and add additional genomes (in case they were added to the config files)." 
 	echo "  --dry Invokes a dry-run. Corresponds to: snakemake -n"
@@ -200,12 +200,48 @@ if [[ $RUNMODE == "orthology" ]]; then
   fi
 fi
 
+
+if [[ $RUNMODE == "filter-orthology" ]]; then
+  if [[ ! -f ".phylogenomics_setup.done" ]]; then
+	echo "You must first run phylogenomics --setup to run the pipeline"
+	exit 0
+  fi
+  if [[ ! -f "checkpoints/orthology.done" ]]; then
+        echo "You must first phylogenomics -m orthology to run this part of the pipeline."
+        exit 0
+  fi
+  echo "Runmode set to: filter-orthology. Will filter BUSCO runs according to parameters specified in the config file."
+  if [[ $DRY != "-n" ]]; then
+	echo "Will remove previous results..."
+	rm -fr results/busco_sequences
+	rm -fr results/busco_sequences_deduplicated
+	rm -f checkpoints/filter_orthology.done
+	rm -f results/checkpoints/create_sequence_files.done
+	rm -f results/checkpoints/remove_duplicated_sequence_files.done
+  fi
+  if [[ $CLUSTER == "slurm" ]]; then
+          export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
+          mkdir -p .conda_pkg_tmp
+          snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster '$(pwd)/bin/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS -r filter_orthology $SM_ARGS $DRY
+  	unset CONDA_PKGS_DIRS
+  elif [[ $CLUSTER == "sge" ]]; then
+  	snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS -r filter_orthology $SM_ARGS $DRY
+  elif [[ $CLUSTER == "torque" ]]; then
+        snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS -r filter_orthology $SM_ARGS $DRY
+  elif [[ $CLUSTER == "serial" ]]; then
+    snakemake --use-conda --use-singularity --singularity-args "$SI_ARGS" -pr --notemp $SM_ARGS -r filter_orthology $DRY
+  else
+          echo "Submission system not recognized"
+          exit 1
+  fi
+fi
+
 if [[ $RUNMODE == *"align"* ]]; then
   if [[ ! -f ".phylogenomics_setup.done" ]]; then
         echo "You must first run phylogenomics --setup to run the pipeline"
         exit 0
   fi
-  if [[ ! -f "checkpoints/part1.done" ]]; then
+  if [[ ! -f "checkpoints/filter_orthology.done" ]]; then
         echo "You must first phylogenomics -m busco to run this part of the pipeline"
         exit 0
   fi

--- a/phylociraptor
+++ b/phylociraptor
@@ -13,7 +13,7 @@ usage() {
         echo "  -c <cluster_config_file> Path to cluster config file in YAML format (mandatory). "
         echo "  -s <snakemake_args> Additional arguments passed on to the snakemake command (optional). snakemake is run with --immediate-submit -pr --notemp --latency-wait 600 --use-singularity --jobs 1001 by default."
         echo "  -i \"<singularity_args>\" Additional arguments passed on to singularity (optional). Singularity is run with -B /tmp:/usertmp by default."
-        echo "  -m <mode> Specify runmode, separated by comma. Options: orthology, filter-orthology, align, model, tree, speciestree"
+        echo "  -m <mode> Specify runmode, separated by comma. Options: orthology, filter-orthology, align, filter-align, model, tree, speciestree"
 	echo
 	echo "  --add-genomes will check for and add additional genomes (in case they were added to the config files)." 
 	echo "  --dry Invokes a dry-run. Corresponds to: snakemake -n"
@@ -242,7 +242,7 @@ if [[ $RUNMODE == "align" ]]; then
         exit 0
   fi
   if [[ ! -f "checkpoints/filter_orthology.done" ]]; then
-        echo "You must first phylogenomics -m filter-orthology to run this part of the pipeline"
+        echo "You must first phylogenomics -m filter-orthology to run this part of the pipeline."
         exit 0
   fi
   mkdir -p .usr_tmp
@@ -274,7 +274,7 @@ if [[ $RUNMODE == "filter-align" ]]; then
         exit 0
   fi
   mkdir -p .usr_tmp
-  echo "Runmode set to: filter-align. Will filter alignments based ony settings in config file."
+  echo "Runmode set to: filter-align. Will filter alignments based on settings in config file."
   if [[ $DRY != "-n" ]]; then
 	echo "Will remove previous results..."
 	rm -fr results/filtered_alignments/*
@@ -304,15 +304,29 @@ if [[ $RUNMODE == *"model"* ]]; then
         echo "You must first run phylogenomics --setup to run the pipeline"
         exit 0
   fi
- if [[ ! -f "checkpoints/part1.done" ]]; then
-        echo "You must first phylogenomics -m busco to run this part of the pipeline"
+ if [[ ! -f "checkpoints/orthology.done" ]]; then
+        echo "You must first phylogenomics -m orthology to run this part of the pipeline"
         exit 0
   fi
- if [[ ! -f "checkpoints/part2.done" ]]; then
+
+ if [[ ! -f "checkpoints/filter_orthology.done" ]]; then
+        echo "You must first phylogenomics -m filter-orthology to run this part of the pipeline"
+        exit 0
+  fi
+ if [[ ! -f "checkpoints/align.done" ]]; then
         echo "You must first phylogenomics -m align to run this part of the pipeline"
         exit 0
   fi
 
+ if [[ ! -f "checkpoints/align_trim.done" ]]; then
+        echo "You must first phylogenomics -m align to run this part of the pipeline"
+        exit 0
+  fi
+
+ if [[ ! -f "checkpoints/filter_align.done" ]]; then
+        echo "You must first phylogenomics -m filter-align to run this part of the pipeline"
+        exit 0
+  fi
   echo "Runmode set to: model. Will run substitution model testing with IQTREE"
   if [[ $CLUSTER == "slurm" ]]; then
           export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
@@ -337,15 +351,30 @@ if [[ $RUNMODE == "tree" ]]; then
         echo "You must first run phylogenomics --setup to run the pipeline"
         exit 0
   fi
- if [[ ! -f "checkpoints/part1.done" ]]; then
-        echo "You must first phylogenomics -m busco to run this part of the pipeline"
+
+ if [[ ! -f "checkpoints/orthology.done" ]]; then
+        echo "You must first phylogenomics -m orthology to run this part of the pipeline"
         exit 0
   fi
- if [[ ! -f "checkpoints/part2.done" ]]; then
+
+ if [[ ! -f "checkpoints/filter_orthology.done" ]]; then
+        echo "You must first phylogenomics -m filter-orthology to run this part of the pipeline"
+        exit 0
+  fi
+ if [[ ! -f "checkpoints/align.done" ]]; then
         echo "You must first phylogenomics -m align to run this part of the pipeline"
         exit 0
   fi
 
+ if [[ ! -f "checkpoints/align_trim.done" ]]; then
+        echo "You must first phylogenomics -m align to run this part of the pipeline"
+        exit 0
+  fi
+
+ if [[ ! -f "checkpoints/filter_align.done" ]]; then
+        echo "You must first phylogenomics -m filter-align to run this part of the pipeline"
+        exit 0
+  fi
   echo "Runmode set to: tree. Will run concatenated (supermatix) tree reconstruction."
   if [[ $CLUSTER == "slurm" ]]; then
           export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
@@ -369,15 +398,30 @@ if [[ $RUNMODE == *"speciestree"* ]]; then
         echo "You must first run phylogenomics --setup to run the pipeline"
         exit 0
   fi
- if [[ ! -f "checkpoints/part1.done" ]]; then
-        echo "You must first phylogenomics -m busco to run this part of the pipeline"
+
+ if [[ ! -f "checkpoints/orthology.done" ]]; then
+        echo "You must first phylogenomics -m orthology to run this part of the pipeline"
         exit 0
   fi
- if [[ ! -f "checkpoints/part2.done" ]]; then
+
+ if [[ ! -f "checkpoints/filter_orthology.done" ]]; then
+        echo "You must first phylogenomics -m filter-orthology to run this part of the pipeline"
+        exit 0
+  fi
+ if [[ ! -f "checkpoints/align.done" ]]; then
         echo "You must first phylogenomics -m align to run this part of the pipeline"
         exit 0
   fi
 
+ if [[ ! -f "checkpoints/align_trim.done" ]]; then
+        echo "You must first phylogenomics -m align to run this part of the pipeline"
+        exit 0
+  fi
+
+ if [[ ! -f "checkpoints/filter_align.done" ]]; then
+        echo "You must first phylogenomics -m filter-align to run this part of the pipeline"
+        exit 0
+  fi
   echo "Runmode set to: speciestree. Will run species tree reconstruction."
   if [[ $CLUSTER == "slurm" ]]; then
           export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"

--- a/phylociraptor
+++ b/phylociraptor
@@ -280,7 +280,7 @@ if [[ $RUNMODE == "filter-align" ]]; then
 	rm -fr results/filtered_alignments/*
 	rm -f results/checkpoints/aggregate_align.done
 	rm -f results/statistics/alignment_filter_information.txt
-	rm -f results/statistics/statistics_alignments.txt
+	rm -f results/statistics/statistics_filtered.txt
 	rm -f checkpoints/filter_align.done
   fi
   if [[ $CLUSTER == "slurm" ]]; then

--- a/phylociraptor
+++ b/phylociraptor
@@ -278,7 +278,7 @@ if [[ $RUNMODE == "filter-align" ]]; then
   if [[ $DRY != "-n" ]]; then
 	echo "Will remove previous results..."
 	rm -fr results/filtered_alignments/*
-	rm -f results/checkpoints/aggregate_align.done
+	rm -fr results/checkpoints/filter_alignments.done
 	rm -f results/statistics/alignment_filter_information.txt
 	rm -f results/statistics/statistics_filtered.txt
 	rm -f checkpoints/filter_align.done

--- a/rules/align_trim.smk
+++ b/rules/align_trim.smk
@@ -148,7 +148,8 @@ rule get_alignment_statistics:
 		alignment_method = config["alignment"]["method"],
 		alignment_params = config["alignment"]["parameters"],
 		trimming_method = config["trimming"]["method"],
-		trimming_params = config["trimming"]["parameters"]
+		trimming_params = config["trimming"]["parameters"],
+		pars_sites = config["filtering"]["min_parsimony_sites"]
 	singularity: "docker://reslp/concat:0.21"
 	shell:
 		"""
@@ -162,4 +163,5 @@ rule get_alignment_statistics:
 		echo "Alignment parameters:\t{params.alignment_params}" >> {output.overview_statistics}
 		echo "Trimming method:\t{params.trimming_method}" >> {output.overview_statistics}
 		echo "Trimming parameters:\t{params.trimming_params}" >> {output.overview_statistics}
+		echo "Min Parssites:\t{params.pars_sites}" >> {output.overview_statistics}
 		"""

--- a/rules/align_trim.smk
+++ b/rules/align_trim.smk
@@ -8,7 +8,6 @@ rule align:
 		sequence_file = "results/busco_sequences_deduplicated/{busco}_all.fas"
 	output:
 		alignment = "results/alignments/{busco}_aligned.fas",
-		checkpoint = "results/checkpoints/mafft/{busco}_aligned.done"
 	benchmark:
 		"results/statistics/benchmarks/align/align_{busco}.txt"
 	singularity:
@@ -20,7 +19,6 @@ rule align:
 	shell:
 		"""
 		mafft {params} {input.sequence_file} > {output.alignment}
-		touch {output.checkpoint}
 		"""
 
 if config["trimming"]["method"] == "trimal":
@@ -29,7 +27,6 @@ if config["trimming"]["method"] == "trimal":
 			rules.align.output.alignment
 		output:
 			trimmed_alignment = "results/trimmed_alignments/{busco}_aligned_trimmed.fas",
-			checkpoint = "results/checkpoints/trimmed/{busco}_trimmed.done"
 		benchmark:
 			"results/statistics/benchmarks/align/trim_{busco}.txt"
 		params:
@@ -39,7 +36,6 @@ if config["trimming"]["method"] == "trimal":
 		shell:
 			"""
 			trimal {params.trimmer} -in {input} -out {output.trimmed_alignment}
-			touch {output.checkpoint}
 			"""
 elif config["trimming"]["method"] == "aliscore":
 	rule trim:
@@ -47,7 +43,6 @@ elif config["trimming"]["method"] == "aliscore":
 			rules.align.output.alignment
 		output:
 			trimmed_alignment = "results/trimmed_alignments/{busco}_aligned_trimmed.fas",
-			checkpoint = "results/checkpoints/trimmed/{busco}_trimmed.done"
 		benchmark:
 			"results/statistics/benchmarks/align/trim_{busco}.txt"
 		params:
@@ -85,7 +80,6 @@ elif config["trimming"]["method"] == "aliscore":
 				fi
 				mv ALICUT_{params.busco}_aligned.fas {params.wd}/{output.trimmed_alignment}
 			fi
-			touch {params.wd}/{output.checkpoint}
 			"""
 			
 #def aggregate_trimmed_alignments(wildcards):
@@ -93,15 +87,24 @@ elif config["trimming"]["method"] == "aliscore":
 #    file_names = expand("results/trimmed_alignments/{busco}_aligned_trimmed.fas", busco = glob_wildcards(os.path.join(checkpoint_output, "{busco}_all.fas")).busco)
 #    return file_names
 
-
-
-rule get_all_trimmed_files:
+rule aggregate_align:
 	input:
 		expand("results/trimmed_alignments/{bus}_aligned_trimmed.fas", bus=BUSCOS)
 	output:
-		checkpoint = "results/checkpoints/get_all_trimmed_files.done"
+		checkpoint = "results/checkpoints/aggregate_align.done"
+	shell:
+		"""
+		touch {output.checkpoint}
+		"""
+
+
+rule get_all_trimmed_alignments:
+	input:
+		expand("results/trimmed_alignments/{bus}_aligned_trimmed.fas", bus=BUSCOS)
+	output:
+		checkpoint = "results/checkpoints/get_all_trimmed_alignments.done"
 	benchmark:
-		"results/statistics/benchmarks/align/get_all_trimmed_files.txt"
+		"results/statistics/benchmarks/align/get_all_trimmed_alignments.txt"
 	singularity:
 		"docker://reslp/biopython_plus:1.77"
 	params:
@@ -134,11 +137,10 @@ rule get_all_trimmed_files:
 
 rule get_alignment_statistics:
 	input:
-		rules.get_all_trimmed_files.output.checkpoint
+		rules.aggregate_align.output.checkpoint
 	output:
 		statistics_alignment = "results/statistics/statistics_alignments.txt",
 		statistics_trimmed = "results/statistics/statistics_trimmed.txt",
-		statistics_filtered = "results/statistics/statistics_filtered.txt",
 		overview_statistics = "results/statistics/align_trim_overview_statistics.txt"
 	params:
 		ids = config["species"],
@@ -156,8 +158,6 @@ rule get_alignment_statistics:
 		mv results/statistics/statistics.txt {output.statistics_alignment}
 		concat.py -d results/trimmed_alignments/ -t results/statistics/ids_alignments.txt --runmode concat -o results/statistics/ --biopython --statistics --seqtype aa --noseq
 		mv results/statistics/statistics.txt {output.statistics_trimmed}
-		concat.py -d results/filtered_alignments/ -t results/statistics/ids_alignments.txt --runmode concat -o results/statistics/ --biopython --statistics --seqtype aa --noseq
-		mv results/statistics/statistics.txt {output.statistics_filtered}
 		echo "Alignment method:\t{params.alignment_method}" > {output.overview_statistics}
 		echo "Alignment parameters:\t{params.alignment_params}" >> {output.overview_statistics}
 		echo "Trimming method:\t{params.trimming_method}" >> {output.overview_statistics}

--- a/rules/filter-align_trim.smk
+++ b/rules/filter-align_trim.smk
@@ -1,0 +1,52 @@
+import subprocess
+
+BUSCOS, = glob_wildcards("results/busco_sequences_deduplicated/{busco}_all.fas")
+
+rule filter_alignments:
+	input:
+		alignments = expand("results/trimmed_alignments/{bus}_aligned_trimmed.fas", bus=BUSCOS),
+		stats = rules.get_alignment_statistics.output.statistics_trimmed
+	output:
+		checkpoint = "results/checkpoints/filter_alignments.done",
+		filter_info = "results/statistics/alignment_filter_information.txt"
+	benchmark:
+		"results/statistics/benchmarks/align/filter_alignments.txt"
+	singularity:
+		"docker://reslp/biopython_plus:1.77"
+	params:
+		wd = os.getcwd(),
+		trimming_method = config["trimming"]["method"],
+		min_pars_sites = config["filtering"]["min_parsimony_sites"]
+	shell:
+		"""
+		if [[ -d results/filtered_alignments ]]; then
+			rm -rf results/filtered_alignments
+		fi
+		mkdir results/filtered_alignments
+		
+		for file in results/trimmed_alignments/*.fas;
+		do
+			python bin/filter_alignments.py --alignments {params.wd}/$file --outdir "{params.wd}/results/filtered_alignments" --statistics-file {input.stats} --min-parsimony {params.min_pars_sites} > {output.filter_info}
+		done
+		echo "$(date) - Number of alignments: $(ls results/alignments/*.fas | wc -l)" >> results/statistics/runlog.txt
+		echo "$(date) - Number of trimmed alignments: $(ls results/filtered_alignments/*.fas | wc -l)" >> results/statistics/runlog.txt
+		echo "$(date) - Number of alignments after filtering: $(ls results/filtered_alignments/*.fas | wc -l)" >> results/statistics/runlog.txt
+		touch {output.checkpoint}
+		"""
+
+rule get_filter_statistics:
+	input:
+		rules.filter_alignments.output.checkpoint
+	output:
+		statistics_filtered = "results/statistics/statistics_filtered.txt"	
+	params:
+		ids = config["species"],
+		datatype = config["filtering"]["seq_type"],
+	singularity: "docker://reslp/concat:0.21"
+	shell:
+		"""
+		tail -n +2 {params.ids} | awk -F "," '{{print $1;}}' | sed 's/^"//g' | sed 's/"$//g' | sed 's/ /_/g' > results/statistics/ids_alignments.txt
+		# here the ids for the alignments need to be filtered as well first. maybe this can be changed in the concat.py script, so that an id file is not needed anymore.
+		concat.py -d results/filtered_alignments/ -t results/statistics/ids_alignments.txt --runmode concat -o results/statistics/ --biopython --statistics --seqtype {params.datatype} --noseq
+		mv results/statistics/statistics.txt {output.statistics_filtered}
+		"""

--- a/rules/filter-align_trim.smk
+++ b/rules/filter-align_trim.smk
@@ -26,7 +26,7 @@ rule filter_alignments:
 		
 		for file in results/trimmed_alignments/*.fas;
 		do
-			python bin/filter_alignments.py --alignments {params.wd}/$file --outdir "{params.wd}/results/filtered_alignments" --statistics-file {input.stats} --min-parsimony {params.min_pars_sites} > {output.filter_info}
+			python bin/filter_alignments.py --alignments {params.wd}/$file --outdir "{params.wd}/results/filtered_alignments" --statistics-file {input.stats} --min-parsimony {params.min_pars_sites} >> {output.filter_info}
 		done
 		echo "$(date) - Number of alignments: $(ls results/alignments/*.fas | wc -l)" >> results/statistics/runlog.txt
 		echo "$(date) - Number of trimmed alignments: $(ls results/filtered_alignments/*.fas | wc -l)" >> results/statistics/runlog.txt

--- a/rules/filter-orthology.smk
+++ b/rules/filter-orthology.smk
@@ -1,0 +1,72 @@
+rule create_sequence_files:
+	input:
+		busco_table = rules.extract_busco_table.output.busco_table,
+		checkpoint = rules.orthology.output
+	output:
+		sequence_dir = directory("results/busco_sequences"),
+		checkpoint = "results/checkpoints/create_sequence_files.done",
+		genome_statistics = "results/statistics/orthology_filtering_genomes_statistics.txt",
+		gene_statistics = "results/statistics/orthology_filtering_gene_statistics.txt"
+	benchmark:
+		"results/statistics/benchmarks/busco/create_sequence_files.txt"
+	params:
+		cutoff=config["filtering"]["cutoff"],
+		minsp=config["filtering"]["minsp"],
+		busco_dir = "results/busco",
+		seqtype = config["filtering"]["seq_type"]
+	singularity:
+		"docker://reslp/biopython_plus:1.77"
+	shell:
+		""" 
+		mkdir -p {output.sequence_dir}
+		# remove files in case there are already some:
+		rm -f {output.sequence_dir}/*
+		python bin/create_sequence_files.py --type {params.seqtype} --busco_table {input.busco_table} --busco_results {params.busco_dir} --cutoff {params.cutoff} --outdir {output.sequence_dir} --minsp {params.minsp} --genome_statistics {output.genome_statistics} --gene_statistics {output.gene_statistics}
+		touch {output.checkpoint}   
+		"""
+
+rule remove_duplicated_sequence_files:
+	input:
+		checkpoint = rules.create_sequence_files.output.checkpoint
+	output:
+		checkpoint = "results/checkpoints/remove_duplicated_sequence_files.done",
+		statistics = "results/statistics/duplicated_sequences_handling_information.txt"
+	benchmark:
+		"results/statistics/benchmarks/busco/remove_duplicated_sequence_files.txt"
+	singularity: "docker://reslp/biopython_plus:1.77"
+	params:
+		wd = os.getcwd(),
+		dupseq=config["filtering"]["dupseq"]
+	shell:
+		"""
+		if [[ -d results/busco_sequences_deduplicated ]]; then
+			rm -rf results/busco_sequences_deduplicated
+		fi
+		mkdir results/busco_sequences_deduplicated
+		
+		rm -f {output.statistics}
+		
+		if [[ {params.dupseq} == "persample" ]];
+		then
+			echo "$(date) - BUSCO files will be filtered on a per-sample basis. This could lower the number of species in the final tree." >> results/statistics/runlog.txt
+		else
+			echo "$(date) - BUSCO files will be filtered on a per BUSCO gene basis. This could lower the number of genes used to calculate the final tree." >> results/statistics/runlog.txt
+		fi
+		
+		for file in results/busco_sequences/*.fas;
+			do
+			if [[ {params.dupseq} == "persample" ]];
+			then
+				# per sequence filtering
+				python bin/filter_alignments.py --alignments {params.wd}/$file --outdir "{params.wd}/results/busco_sequences_deduplicated" --per_sample >> {output.statistics}
+			else
+				# whole alignment filtering
+				python bin/filter_alignments.py --alignments {params.wd}/$file --outdir "{params.wd}/results/busco_sequences_deduplicated" >> {output.statistics}
+			fi
+		done
+		#gather runtime statistics
+		for file in $(ls results/statistics/benchmarks/busco/); do printf $file"\t"; sed '2q;d' results/statistics/benchmarks/busco/$file; done > results/statistics/benchmark_all_busco_runs.bench	
+		echo "$(date) - Number of BUSCO sequence files: $(ls results/busco_sequences/*.fas | wc -l)" >> results/statistics/runlog.txt
+		echo "$(date) - Number of deduplicated BUSCO sequence files: $(ls results/busco_sequences_deduplicated/*.fas | wc -l)" >> results/statistics/runlog.txt
+		touch {output.checkpoint}
+		"""

--- a/rules/model.smk
+++ b/rules/model.smk
@@ -37,7 +37,7 @@ BUSCOS, = glob_wildcards("results/filtered_alignments/{busco}_aligned_trimmed.fa
 
 rule modeltest:
 	input:
-		rules.part2.output,
+		rules.align_trim.output,
 		alignment = "results/filtered_alignments/{busco}_aligned_trimmed.fas"
 	output:
 		logfile = "results/modeltest/{busco}/{busco}.log",

--- a/rules/orthology.smk
+++ b/rules/orthology.smk
@@ -71,7 +71,7 @@ rule busco:
 	input:
 		checks = expand("results/checkpoints/busco/busco_{species}.done", species=glob_wildcards("results/assemblies/{species}.fna").species)
 	output:
-		"checkpoints/busco.done"
+		"results/checkpoints/busco.done"
 	shell:
 		"""
 		touch {output}

--- a/rules/orthology.smk
+++ b/rules/orthology.smk
@@ -92,78 +92,9 @@ rule extract_busco_table:
 		busco_dir = "results/busco/"
 	shell:
 		"""
-		python bin/extract_busco_table.py --hmm {input.busco_set}/hmms --busco_results {params.busco_dir} > {output.busco_table}
+		python bin/extract_busco_table.py --hmm {input.busco_set}/hmms --busco_results {params.busco_dir} -o {output.busco_table}
 		echo "species\tcomplete\tsingle_copy\tduplicated\tfragmented\tmissing\ttotal" > results/statistics/busco_summary.txt
 		for file in $(ls results/busco/*/run_busco/short_summary_busco.txt);do  name=$(echo $file | sed 's#results/busco/##' | sed 's#/run_busco/short_summary_busco.txt##'); printf $name; cat $file | grep -P '\t\d' | awk -F "\t" '{{printf "\t"$2}}' | awk '{{print}}'; done >> results/statistics/busco_summary.txt
 		touch {output.checkpoint}
 		"""
 
-rule create_sequence_files:
-	input:
-		busco_table = rules.extract_busco_table.output.busco_table,
-		checkpoint = rules.busco.output
-	output:
-		sequence_dir = directory("results/busco_sequences"),
-		checkpoint = "results/checkpoints/create_sequence_files.done",
-		statistics = "results/statistics/create_sequence_files.txt"
-	benchmark:
-		"results/statistics/benchmarks/busco/create_sequence_files.txt"
-	params:
-		cutoff=config["filtering"]["cutoff"],
-		minsp=config["filtering"]["minsp"],
-		busco_dir = "results/busco",
-		seqtype = config["filtering"]["seq_type"]
-	singularity:
-		"docker://reslp/biopython_plus:1.77"
-	shell:
-		"""
-		mkdir -p {output.sequence_dir}
-		python bin/create_sequence_files.py --type {params.seqtype} --busco_table {input.busco_table} --busco_results {params.busco_dir} --cutoff {params.cutoff} --outdir {output.sequence_dir} --minsp {params.minsp} > {output.statistics}
-		touch {output.checkpoint}   
-		"""
-
-rule remove_duplicated_sequence_files:
-	input:
-		checkpoint = rules.create_sequence_files.output.checkpoint
-	output:
-		checkpoint = "results/checkpoints/remove_duplicated_sequence_files.done",
-		statistics = "results/statistics/duplicated_sequences_handling_information.txt"
-	benchmark:
-		"results/statistics/benchmarks/busco/remove_duplicated_sequence_files.txt"
-	singularity: "docker://reslp/biopython_plus:1.77"
-	params:
-		wd = os.getcwd(),
-		dupseq=config["filtering"]["dupseq"]
-	shell:
-		"""
-		if [[ -d results/busco_sequences_deduplicated ]]; then
-			rm -rf results/busco_sequences_deduplicated
-		fi
-		mkdir results/busco_sequences_deduplicated
-		
-		rm -f {output.statistics}
-		
-		if [[ {params.dupseq} == "persample" ]];
-		then
-			echo "$(date) - BUSCO files will be filtered on a per-sample basis. This could lower the number of species in the final tree." >> results/statistics/runlog.txt
-		else
-			echo "$(date) - BUSCO files will be filtered on a per BUSCO gene basis. This could lower the number of genes used to calculate the final tree." >> results/statistics/runlog.txt
-		fi
-		
-		for file in results/busco_sequences/*.fas;
-			do
-			if [[ {params.dupseq} == "persample" ]];
-			then
-				# per sequence filtering
-				python bin/filter_alignments.py --alignments {params.wd}/$file --outdir "{params.wd}/results/busco_sequences_deduplicated" --per_sample >> {output.statistics}
-			else
-				# whole alignment filtering
-				python bin/filter_alignments.py --alignments {params.wd}/$file --outdir "{params.wd}/results/busco_sequences_deduplicated" >> {output.statistics}
-			fi
-		done
-		#gather runtime statistics
-		for file in $(ls results/statistics/benchmarks/busco/); do printf $file"\t"; sed '2q;d' results/statistics/benchmarks/busco/$file; done > results/statistics/benchmark_all_busco_runs.bench	
-		echo "$(date) - Number of BUSCO sequence files: $(ls results/busco_sequences/*.fas | wc -l)" >> results/statistics/runlog.txt
-		echo "$(date) - Number of deduplicated BUSCO sequence files: $(ls results/busco_sequences_deduplicated/*.fas | wc -l)" >> results/statistics/runlog.txt
-		touch {output.checkpoint}
-		"""

--- a/rules/speciestree.smk
+++ b/rules/speciestree.smk
@@ -1,6 +1,6 @@
 rule iqtree_gene_trees:
 	input:
-		rules.part2.output,
+		rules.align_trim.output,
 		busco = "results/filtered_alignments/{busco}_aligned_trimmed.fas"
 	output:
 		checkpoint = "results/checkpoints/gene_trees/{busco}_genetree.done",

--- a/rules/tree.smk
+++ b/rules/tree.smk
@@ -1,7 +1,7 @@
 if "raxml" in config["tree"]["method"]:
 	rule concatenate:
 		input:
-			checkpoint = rules.part2.output
+			checkpoint = rules.align_trim.output
 		output:
 			checkpoint = "results/checkpoints/concatenate.done",
 			alignment = "results/phylogeny/concat.fas",
@@ -78,7 +78,7 @@ else:
 if "iqtree" in config["tree"]["method"]:
 	rule iqtree:
 		input:
-			rules.part2.output
+			rules.align_trim.output
 		output:
 			checkpoint = "results/checkpoints/iqtree.done",
 			statistics = "results/statistics/iqtree_statistics.txt"


### PR DESCRIPTION
This includes several changes to the pipeline:
- Added new runmode -m filter-orthology to filter BUSCO results according to settings in config.yaml
- Samples are now filtered according to BUSCO completeness properly
- Added new runmode -m filter-align to filter trimmed alignments according to settings in config.yaml
- Trimmed alignments can now be filtered according to the number of parsimony informative sites.
- BUSCO runmode is now called orthology (-m orthology) to have the possibility to user other methods for orthology inference in the future without having to change the name of the step.
- Improved statistics output in report. Now it is more transparent what gets filtered when.
- Update README to reflect these changes.
- Update the phylociraptor script to reflect these changes.

Several small commits could be necessary in case problems show up with this new functionality.