### PR TITLE
Add immediate_submit submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bin/immediate-submit"]
+	path = bin/immediate-submit
+	url = https://github.com/reslp/immediate-submit.git

--- a/data/cluster-config-SLURM.yaml.template
+++ b/data/cluster-config-SLURM.yaml.template
@@ -1,8 +1,7 @@
 __default__:
    time: "72:00:00"
-   n: 1
    ntasks: 1
-   J: default
+   job-name: default
    hint: nomultithread
    mem: 4G
    partition: mem_0096 
@@ -10,96 +9,96 @@ __default__:
    output: $(pwd)/log/slurm-%j.out
    error: $(pwd)/log/slurm-%j.err
 download_genomes:
-   J: dlgenomes
+   job-name: dlgenomes
    mem: 12G
 rename_assemblies:
-   J: renasse
+   job-name: renasse
 download_busco_set:
-   J: dlbuscoset
+   job-name: dlbuscoset
 prepare_augustus:
-   J: prepaug
+   job-name: prepaug
 get_genome_download_statistics:
-   J: ggendlstat
+   job-name: ggendlstat
 setup:
-   J: setup
+   job-name: setup
 busco:
-   J: BUSCO 
+   job-name: BUSCO 
 orthology:
-   J: ORTHOLOGY
+   job-name: ORTHOLOGY
 filter_orthology:
-   J: FILTORTH
+   job-name: FILTORTH
 filter_alignments:
-   J: filtalgn
+   job-name: filtalgn
 part_filter_align:
-   J: FAL
+   job-name: FAL
 align_trim:
-   J: alntri
+   job-name: alntri
 filter_align:
-   J: FAL
+   job-name: FAL
 get_filter_statistics:
-   J: getfilstat 
+   job-name: getfilstat 
 run_busco:
-   J: rBUSCO
+   job-name: rBUSCO
    mem: 32G
 extract_busco_table:
-   J: exBUSCO
+   job-name: exBUSCO
    mem: 12G
 create_sequence_files:
-   J: exSeqfiles
+   job-name: exSeqfiles
    mem: 12G
 remove_duplicated_sequence_files:
-   J: remdupseq
+   job-name: remdupseq
    mem: 12G
 get_all_trimmed_files:
-   J: gettrimfiles
+   job-name: gettrimfiles
    mem: 12G
 get_alignment_statistics:
-   J: getalnstat
+   job-name: getalnstat
 align:
-   J: align
+   job-name: align
    time: "02:00:00"
    mem: 10G
 trim:
-   J: trim
+   job-name: trim
    mem: 10G
 iqtree:
-   J: iqtree
+   job-name: iqtree
    mem: 94G
 concatenate:
-   J: concat
+   job-name: concat
    mem: 8G
 modeltest:
-   J: mt
+   job-name: mt
    mem: 64G
 aggregate_best_models:
-   J: aggmodels
+   job-name: aggmodels
    mem: 10G
 raxmlng:
-   J: raxmlng
+   job-name: raxmlng
    mem: 94G
 phylobayes:
-   J: phylobayes
+   job-name: phylobayes
    mem: 16G
 merge_phylobayes_chains:
-   J: merge_phylobayes
+   job-name: merge_phylobayes
    mem: 4G
 part2:
-   J: part2
+   job-name: part2
    mem: 4G
 part3:
-   J: part3
+   job-name: part3
    mem: 4G
 astral_species_tree:
-   J: astral
+   job-name: astral
    mem: 48G
 iqtree_gene_trees:
-   J: iqtgenetrees
+   job-name: iqtgenetrees
    mem: 32G
 aggregate_gene_trees:
-   J: agg_genetrees
+   job-name: agg_genetrees
 njtree:
-   J: njtree
+   job-name: njtree
    mem: 16G
 partition_alignment:
-   J: partalgn
+   job-name: partalgn
    mem: 10G

--- a/docs/indepth/cluster-config-SLURM.yaml
+++ b/docs/indepth/cluster-config-SLURM.yaml
@@ -1,8 +1,7 @@
 __default__:
    time: "72:00:00"
-   n: 1
    ntasks: 1
-   J: default
+   job-name: default
    hint: nomultithread
    mem: 4G
    partition: mem_0096 
@@ -10,22 +9,21 @@ __default__:
    output: $(pwd)/log/slurm-%j.out
    error: $(pwd)/log/slurm-%j.err
 busco:
-   J: BUSCO 
+   job-name: BUSCO 
 orthology:
-   J: ORTHOLOGY
+   job-name: ORTHOLOGY
 filter_orthology:
-   J: FILTORTH
+   job-name: FILTORTH
 filter_alignments:
-   J: filtalgn
+   job-name: filtalgn
 part_filter_align:
-   J: FAL
+   job-name: FAL
 align_trim:
-   J: alntri
+   job-name: alntri
 filter_align:
-   J: FAL
+   job-name: FAL
 get_filter_statistics:
-   J: getfilstat 
+   job-name: getfilstat 
 run_busco:
-   J: rBUSCO
-   ntasks: 16
+   job-name: rBUSCO
    mem: 32G

--- a/docs/indepth/config_files.rst
+++ b/docs/indepth/config_files.rst
@@ -187,7 +187,7 @@ Here are the first 30 lines of the config file for a SLURM cluster.
 .. literalinclude:: cluster-config-SLURM.yaml
         :language: python
         :linenos:
-	:emphasize-lines: 2,8,9
+	:emphasize-lines: 2,7,8
 
 Typically it will only be necessary to change the highlighted lines in the example above. QOS (Quality of service) and partition are usually cluster specific and need to be changed. The walltime limit :bash:`time: "72:00:00"` will also depend on your cluster environment.
 

--- a/docs/introduction/about.rst
+++ b/docs/introduction/about.rst
@@ -42,6 +42,7 @@ dependencies:
 **Alignment:**
 
 * mafft 7.464 - `https://mafft.cbrc.jp/alignment/software/ <https://mafft.cbrc.jp/alignment/software/>`_
+* clustalo 1.2.4 - `http://www.clustal.org/omega/ <http://www.clustal.org/omega/>`_
 
 **Trimming:**
 

--- a/docs/introduction/installation.rst
+++ b/docs/introduction/installation.rst
@@ -31,7 +31,7 @@ The probably best way is to clone the repository directly using git (if availabl
 
 .. code-block:: bash
 
-	$ git clone https://github.com/reslp/phylociraptor.git
+	$ git clone --recurse-submodules https://github.com/reslp/phylociraptor.git
 	$ cd phylocirpator
 	$ ./phylociraptor
 	Welcome to phylociraptor, the rapid phylogenomic tree calculator

--- a/phylociraptor
+++ b/phylociraptor
@@ -14,7 +14,7 @@ if sys.version_info[0] < 3:
 njobs = "10001"
 latency_wait = "10" #in seconds
 singularity_bindpoints = "-B $(pwd)/.usr_tmp:/usertmp"
-debug=True #turn debugging mode on (True) and off (False)
+debug=False #turn debugging mode on (True) and off (False)
 cluster_config_defaults= {"slurm": "data/cluster-config-SLURM.yaml.template", "sge":"data/cluster-config-SGE.yaml.template", "torque":"data/cluster-config-TORQUE.yaml.template"}
 default_help = """
 Welcome to phylociraptor, the rapid phylogenomic tree calculator

--- a/phylociraptor
+++ b/phylociraptor
@@ -240,7 +240,7 @@ def determine_submission_mode(flag):
 	if "serial" in flag:
 		return ["--cores"]
 	else:
-		return ["--cluster", 'bin/immediate_submit.py {dependencies} %s' % flag, "--immediate-submit", "--jobs", njobs, "--notemp"]
+		return ["--cluster", 'bin/immediate-submit/immediate_submit.py {dependencies} %s' % flag, "--immediate-submit", "--jobs", njobs, "--notemp"]
 
 def get_flags(flags):
 	mapdict ={


### PR DESCRIPTION
This PR adds to immediate-submit repo as a submodule. This has the advantage that changes to this script can easily by transferred to all pipeline using this script. Also the documentation is updated to account for these changes.
As a consequence, the long version (--) of sbatch flags need to be used in the cluster config file.