### PR TITLE
Attempt to fix hashing when empty strings or None is specified

### DIFF
--- a/bin/libphylociraptor/hashing.py
+++ b/bin/libphylociraptor/hashing.py
@@ -41,8 +41,8 @@ def read_file_from_yaml(read, file, debug=False, wd=""):
 
 def check_parameters(d): #this functions will test parameters to make sure all empty strings are set to None. Otherwise different hashes will be calculated
 	for k, v in d.items():
-		if v == "":
-			d[k] = None
+		if v == None: # check if value is None (it is not specified in the yaml file)
+			d[k] = ""
 			continue
 		if isinstance(v, dict):
 			v = check_parameters(v)		

--- a/bin/libphylociraptor/hashing.py
+++ b/bin/libphylociraptor/hashing.py
@@ -38,6 +38,17 @@ def read_file_from_yaml(read, file, debug=False, wd=""):
 			df = pd.read_csv(file, header=None)
 		return sorted(df.values.tolist())
 
+
+def check_parameters(d): #this functions will test parameters to make sure all empty strings are set to None. Otherwise different hashes will be calculated
+	for k, v in d.items():
+		if v == "":
+			d[k] = None
+			continue
+		if isinstance(v, dict):
+			v = check_parameters(v)		
+	return d	
+
+
 def get_hash(previous, string_of_dict_paths=None, yamlfile=None, returndict=False, debug=False, wd=""):
 	import collections
 	import pandas as pd
@@ -51,6 +62,7 @@ def get_hash(previous, string_of_dict_paths=None, yamlfile=None, returndict=Fals
 	dict_to_hash = {}
 	with open(yamlfile) as f:
 		my_dict = yaml.safe_load(f)
+	my_dict = check_parameters(my_dict)	
 	dic_list = string_of_dict_paths.split(" ")
 	for d in dic_list:
 		if debug:


### PR DESCRIPTION
Christoph, this is an attempt to fix problems with the hashing functionality. It would be great if you could have a lot at this solution when you have time.
Before this fix, hashing treated empty strings and no specified values (which will be set to None internally) differently. 
The solution here is to provide a recursive function to walk through the dict containing the config file values and setting everything to None which has an empty string. 

This does not yet account for how None and empty strings will be treated by phylociraptors rules!
