### PR TITLE
Add better support for unpartitioned analyses

### DIFF
--- a/bin/plot-conflict.R
+++ b/bin/plot-conflict.R
@@ -241,7 +241,11 @@ generate_colors <- function(ncols) {
  
 get_pdf_height <- function(tree) {
 	size_per_tip = 0.2 # in inches
-	return(round(length(tree$tip.label) * size_per_tip, digits=0))
+	total = round(length(tree$tip.label) * size_per_tip, digits=0)
+	if (total < 3) { # adjust plot size for very small trees to a minimum of 3 inches
+		total <- 3
+	}
+	return(total)
 }
 
 cat("Plotting conflicts...\n")
@@ -368,8 +372,10 @@ AABB
 # get some numbers for plot title:
 nconflicts <- as.character(length(names(conflicts_t[conflicts_t == 0])))
 nquartets <- as.character(length(names(conflicts_t)))
+height = get_pdf_height(tree1)
+cat("Trying to calculate sentive height for tree plot based on the size of the tree. Will use:", as.character(height), "inches.\n")
 cat(paste0("Output PDF: conflicts-", treenames[1], "-", treenames[2], "-", nconflicts, "-quartets.pdf\n")) 
-pdf(file=paste0("conflicts-", treenames[1],"-",treenames[2],"-", nconflicts, "-quartets.pdf"), width=10, height=get_pdf_height(tree1))
+pdf(file=paste0("conflicts-", treenames[1],"-",treenames[2],"-", nconflicts, "-quartets.pdf"), width=10, height=height)
   print(t1 + t2 + theme(legend.position="none")  + plot_layout(design = layout) + plot_annotation(title = paste0("An estimation of topological conflict between two trees based on\n", nconflicts, " conficts found in ", nquartets, " analyzed quartets of tips"), caption=paste0("Taxonomic level: ", level,". Random seed: ", seed,". Trees: ",  treenames[1], " (",prefix1,", hash: ", hash1, "), ", treenames[2], " (", prefix2, ", hash: ", hash2, ")\nOutgroup: ", outgroups),  theme = theme(plot.title=element_text(hjust=0.5, size=16))))#+ plot_layout(guides = 'none')# & theme(legend.position='bottom')
 garbage <- dev.off()
   

--- a/bin/plot-heatmap.R
+++ b/bin/plot-heatmap.R
@@ -77,13 +77,14 @@ if (treelistfile == "none") {
 } else {
   cat("Using detailed tree names and reduce to tree list while plotting...\n")
   treelist <- read.csv(treelistfile, sep="\t", header=F)
-print(treelist$V2)
+  print(treelist$V2)
   #remove according to selection
   if (selection != "none") {
 	sel <- as.vector(strsplit(selection, ",")[[1]])
 	cat( "Will select only trees containing: ", paste(sel, " "), "\n")
 	treelist2 <- filter(treelist, grepl(paste(sel, collapse="|"), V2))
   }
+  else { treelist2 <- treelist }
   data <- data[treelist2$V1,]
   data <- data[,treelist2$V1]
   # get new tree names

--- a/bin/plot-t2t-pca.R
+++ b/bin/plot-t2t-pca.R
@@ -66,10 +66,12 @@ for (treepath in treelist$path) {
 cat(paste0("Found ", length(trees), " trees.\n"))
 newtreenames <- c() 
 for (names in strsplit(treelist$path,"/")){
-  newtreenames <-c(newtreenames, paste0(names[3], "-", strsplit(names[5], ".", fixed=T)[[1]][1], "-", strsplit(names[4], "-")[[1]][3]))
+  if (grepl("unpartitioned", names[3], fixed=TRUE) == TRUE) { # check if some trees come from unpartitioned analyses
+	  treebuilder <- gsub("-", "_", names[3])
+  } else { treebuilder <- names[3] } 
+  newtreenames <-c(newtreenames, paste0(treebuilder, "-", strsplit(names[5], ".", fixed=T)[[1]][1], "-", strsplit(names[4], "-")[[1]][3]))
 }
 treelist$path <- newtreenames
-
 all_tips <- c()
 
 cat("Extracting all tips from all trees...\n")

--- a/bin/report.Rmd
+++ b/bin/report.Rmd
@@ -991,15 +991,10 @@ results/phylogeny/
 ```{python getmltreehash, echo=FALSE}
 mltreestats = []
 for bscutoff in all_hashes["mltree"]["mltree"]["per"]:
-	for trimmer in all_hashes["mltree"]["mltree"]["per"][bscutoff]["iqtree"]["iqtree"]:
-		for aligner in all_hashes["mltree"]["mltree"]["per"][bscutoff]["iqtree"]["iqtree"][trimmer]:
-			f = "../results/statistics/mltree/mltree_iqtree_" + aligner + "_" + trimmer + "_" + bscutoff +"_statistics." + all_hashes["mltree"]["mltree"]["per"][bscutoff]["iqtree"]["iqtree"][trimmer][aligner] + ".txt"
-			if os.path.exists(f):
-				mltreestats.append(f)
-	if "raxml" in all_hashes["mltree"]["mltree"]["per"][bscutoff].keys():
-		for trimmer in all_hashes["mltree"]["mltree"]["per"][bscutoff]["raxml"]["iqtree"]:
-			for aligner in all_hashes["mltree"]["mltree"]["per"][bscutoff]["raxml"]["iqtree"][trimmer]:
-				f = "../results/statistics/mltree/mltree_raxml_" + aligner + "_" + trimmer + "_" + bscutoff +"_statistics." + all_hashes["mltree"]["mltree"]["per"][bscutoff]["raxml"]["iqtree"][trimmer][aligner] + ".txt"
+	for treemethod in all_hashes["mltree"]["mltree"]["per"][bscutoff].keys():
+		for trimmer in all_hashes["mltree"]["mltree"]["per"][bscutoff][treemethod]["iqtree"]:
+			for aligner in all_hashes["mltree"]["mltree"]["per"][bscutoff][treemethod]["iqtree"][trimmer]:
+				f = "../results/statistics/mltree/mltree_" + treemethod + "_" + aligner + "_" + trimmer + "_" + bscutoff +"_statistics." + all_hashes["mltree"]["mltree"]["per"][bscutoff][treemethod]["iqtree"][trimmer][aligner] + ".txt"
 				if os.path.exists(f):
 					mltreestats.append(f)
 ```
@@ -1022,6 +1017,9 @@ if (length(files) > 0) {
 	i <- 1
 	for (file in files) {
 		dat[[i]] <- read.table(file, sep=" ", header=F)
+		if (grepl("iqtree-unpartitioned", file, fixed = TRUE) == TRUE) {
+			dat[[i]][1] <- "iqtree-unpartitioned"
+		}
 		i <- i + 1
 	}
 	data_combined <- do.call("rbind", dat)

--- a/data/config.yaml.template
+++ b/data/config.yaml.template
@@ -78,16 +78,19 @@ speciestree:
         astral: ""
 
 mltree:
-    method: ["iqtree"] #["iqtree", "raxml"]
+    method: ["iqtree"] #["iqtree", "raxml", "iqtree-unpartitioned"]
     threads:
         iqtree: 20
         raxml: 20
+        iqtree-unpartitioned: 20
     bootstrap:
         iqtree: 1000
         raxml: 100
+        iqtree-unpartitioned: 1000
     options:
         iqtree: ""
         raxml: ""
+        iqtree-unpartitioned: ""
         
 njtree:
     method: ["quicktree"]

--- a/docs/indepth/mltreeoptions.rst
+++ b/docs/indepth/mltreeoptions.rst
@@ -7,7 +7,9 @@ Different ways to calculate Maximum-Likelihood trees
 =====================================================
 
 Maximum-likelihood trees can be calculated in a variety of ways. The basis typically forms an alignment which can be a supermatrix (concatenated) alignment combining the information of many genes. This alignment is used to infer and optimze parameters of a model which in turn aims to explains the evolutionary history of the included samples to produce a tree. How these models are applied, and which models are used differs widely in the published literature. For example it is possible infer the best fitting evolutionary model (under a specific optimality criterion) for each gene and apply these models in the subsequent maximum-likelihood analysis. It would also be possible to apply a single model to the whole alignment. Or it would be possible to specify a specific model which should be applied to each gene.  
-Additionally the included genes could be filtered before combining them to a concatened alignment. Phylociraptor tries to capture the full breadth of approaches typically applied in large-scale phylogenomic analyses. However the number of differnt combinations can be overwhelming. The purpose of this document is therefore to explain how some of common scenarios to perform maximum-likelihood analyses taking into account different ways to specify models and apply gene filtering can be set up in phylociraptor. 
+
+
+Additionally the included genes could be filtered before combining them to a concatened alignment. Phylociraptor tries to capture the full breadth of approaches typically applied in large-scale phylogenomic analyses. However the number of differnt combinations can be overwhelming. The purpose of this document is therefore to explain how some of the common scenarios to perform maximum-likelihood analyses taking into account different ways to specify models and apply gene filtering can be set up in phylociraptor. 
 
 
 -------------------------------------------------------
@@ -40,9 +42,9 @@ The simples way would be to apply a single model to the complete concatenated al
 
 The relevant settings are:   
 
-Line 2: Make sure to include 0 in the values used for the mean bootstrap cutoff. This is necessary when :bash:`phylociraptor modeltest` has not been run.   
-Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
-Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
+|Line 2: Make sure to include 0 in the values used for the mean bootstrap cutoff. This is necessary when :bash:`phylociraptor modeltest` has not been run.   
+|Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
+|Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
 
 .. note::
 
@@ -116,13 +118,58 @@ Creating an unpartitioned analysis while only using genes with a certain mean bo
 
 The relevant settings are:   
 
-Line 2: Specify which mean bootstrap values you would like to use. 
-Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
-Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
+|Line 2: Specify which mean bootstrap values you would like to use. 
+|Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
+|Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
 
 
 .. note::
 
    Again you could also leave the setting in line 17 blank in which case phylociraptor will use :bash:`-m MFP`(full IQ-Tree modeltest) as default.
+
+
+-----------------------------------------------------------------------------------------------
+Running a partitioned analysis with a fixed model.
+-----------------------------------------------------------------------------------------------
+
+
+.. note::
+
+   This requires that :bash:`phylociraptor modeltest` was run before.
+
+
+.. code-block:: bash
+   :linenos:
+   :emphasize-lines: 2,5,15
+
+    genetree_filtering:
+    bootstrap_cutoff: [50, 60, 70, 80]
+
+    mltree:
+        method: ["iqtree"]
+        threads:
+            iqtree: 20
+            raxml: 20
+            iqtree-unpartitioned: 20
+        bootstrap:
+            iqtree: 1000
+            raxml: 100
+            iqtree-unpartitioned: 1000
+        options:
+            iqtree: "-m C10"
+            raxml: ""
+            iqtree-unpartitioned: ""
+
+
+The relevant settings are:   
+
+|Line 2: Specify which mean bootstrap values you would like to use. 
+|Line 5: Set the method to :bash:`iqtree`.   
+|Line 15: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
+
+
+.. note::
+
+   Note that the behavior here is different to an unpartitioned analysis. When you leave the option in line 15 blank, this will default to using the best models from :bash:`phylociraptor modeltest`.
 
 

--- a/docs/indepth/mltreeoptions.rst
+++ b/docs/indepth/mltreeoptions.rst
@@ -1,0 +1,128 @@
+.. role:: bash(code)
+   :language: bash
+
+
+=====================================================
+Different ways to calculate Maximum-Likelihood trees
+=====================================================
+
+Maximum-likelihood trees can be calculated in a variety of ways. The basis typically forms an alignment which can be a supermatrix (concatenated) alignment combining the information of many genes. This alignment is used to infer and optimze parameters of a model which in turn aims to explains the evolutionary history of the included samples to produce a tree. How these models are applied, and which models are used differs widely in the published literature. For example it is possible infer the best fitting evolutionary model (under a specific optimality criterion) for each gene and apply these models in the subsequent maximum-likelihood analysis. It would also be possible to apply a single model to the whole alignment. Or it would be possible to specify a specific model which should be applied to each gene.  
+Additionally the included genes could be filtered before combining them to a concatened alignment. Phylociraptor tries to capture the full breadth of approaches typically applied in large-scale phylogenomic analyses. However the number of differnt combinations can be overwhelming. The purpose of this document is therefore to explain how some of common scenarios to perform maximum-likelihood analyses taking into account different ways to specify models and apply gene filtering can be set up in phylociraptor. 
+
+
+-------------------------------------------------------
+Creating an unpartitioned analysis using a single model
+-------------------------------------------------------
+
+The simples way would be to apply a single model to the complete concatenated alignment. This step **does not** require :bash:`phylociraptor modeltest`. Have a look at the relevant section of the config file:
+
+.. code-block:: bash
+   :linenos:
+   :emphasize-lines: 2,5,17
+
+    genetree_filtering:
+    bootstrap_cutoff: [0]
+
+    mltree:
+        method: ["iqtree-unpartitioned"]
+        threads:
+            iqtree: 20
+            raxml: 20
+            iqtree-unpartitioned: 20
+        bootstrap:
+            iqtree: 1000
+            raxml: 100
+            iqtree-unpartitioned: 1000
+        options:
+            iqtree: ""
+            raxml: ""
+            iqtree-unpartitioned: "-m C10"
+
+The relevant settings are:   
+
+Line 2: Make sure to include 0 in the values used for the mean bootstrap cutoff. This is necessary when :bash:`phylociraptor modeltest` has not been run.   
+Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
+Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
+
+.. note::
+
+   You can read more about the available models in IQ-Tree `here <http://iqtree.org/doc/Substitution-Models>`_.
+
+
+-------------------------------------------------------------------
+Creating an unpartitioned analysis while testing for the best model
+-------------------------------------------------------------------
+
+This works almost like the above example.
+
+
+.. code-block:: bash
+   :linenos:
+   :emphasize-lines: 17
+
+    genetree_filtering:
+    bootstrap_cutoff: [0]
+
+    mltree:
+        method: ["iqtree-unpartitioned"]
+        threads:
+            iqtree: 20
+            raxml: 20
+            iqtree-unpartitioned: 20
+        bootstrap:
+            iqtree: 1000
+            raxml: 100
+            iqtree-unpartitioned: 1000
+        options:
+            iqtree: ""
+            raxml: ""
+            iqtree-unpartitioned: ""
+
+The only difference to the above example is in line 17. When nothing is specified in this line, phylociraptor will default to :bash:`-m MFP` which includes a full IQ-Tree modeltest.
+
+
+-----------------------------------------------------------------------------------------------
+Creating an unpartitioned analysis while only using genes with a certain mean boostrap support.
+-----------------------------------------------------------------------------------------------
+
+
+.. note::
+
+   This requires that :bash:`phylociraptor modeltest` was run before.
+
+
+.. code-block:: bash
+   :linenos:
+   :emphasize-lines: 2,5,17
+
+    genetree_filtering:
+    bootstrap_cutoff: [50, 60, 70]
+
+    mltree:
+        method: ["iqtree-unpartitioned"]
+        threads:
+            iqtree: 20
+            raxml: 20
+            iqtree-unpartitioned: 20
+        bootstrap:
+            iqtree: 1000
+            raxml: 100
+            iqtree-unpartitioned: 1000
+        options:
+            iqtree: ""
+            raxml: ""
+            iqtree-unpartitioned: "-m C10"
+
+
+The relevant settings are:   
+
+Line 2: Specify which mean bootstrap values you would like to use. 
+Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
+Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
+
+
+.. note::
+
+   Again you could also leave the setting in line 17 blank in which case phylociraptor will use :bash:`-m MFP`(full IQ-Tree modeltest) as default.
+
+

--- a/docs/indepth/mltreeoptions.rst
+++ b/docs/indepth/mltreeoptions.rst
@@ -42,9 +42,9 @@ The simples way would be to apply a single model to the complete concatenated al
 
 The relevant settings are:   
 
-|Line 2: Make sure to include 0 in the values used for the mean bootstrap cutoff. This is necessary when :bash:`phylociraptor modeltest` has not been run.   
-|Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
-|Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
+| Line 2: Make sure to include 0 in the values used for the mean bootstrap cutoff. This is necessary when :bash:`phylociraptor modeltest` has not been run.   
+| Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
+| Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
 
 .. note::
 
@@ -118,9 +118,9 @@ Creating an unpartitioned analysis while only using genes with a certain mean bo
 
 The relevant settings are:   
 
-|Line 2: Specify which mean bootstrap values you would like to use. 
-|Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
-|Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
+| Line 2: Specify which mean bootstrap values you would like to use. 
+| Line 5: Set the method to :bash:`iqtree-unpartitioned`.   
+| Line 17: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
 
 
 .. note::
@@ -163,9 +163,9 @@ Running a partitioned analysis with a fixed model.
 
 The relevant settings are:   
 
-|Line 2: Specify which mean bootstrap values you would like to use. 
-|Line 5: Set the method to :bash:`iqtree`.   
-|Line 15: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
+| Line 2: Specify which mean bootstrap values you would like to use. 
+| Line 5: Set the method to :bash:`iqtree`.   
+| Line 15: Specify the desired substitution model in iqtrees syntax using :bash:`-m`. In this case :bash:`-m C10` for a CAT based mixture model.   
 
 
 .. note::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,6 +80,7 @@ If you run into problems with phylociraptor please follow these steps:
    indepth/output.rst
    indepth/util.rst
    indepth/add_tools.rst
+   indepth/mltreeoptions.rst
 
 .. toctree::
    :caption: Getting help

--- a/phylociraptor
+++ b/phylociraptor
@@ -132,13 +132,17 @@ def check_required_files(runmode, previous_runmode, args):
 	for f in outfile_dict[runmode]:
 		if currenthash != "":
 			f = f.replace("HASH", currenthash)
-		if not os.path.isfile(f) and runmode != "mltree":
+		if not os.path.isfile(f) and runmode not in ["mltree", "bitree"]:
 			print(now(), "ERROR: Some files are missing preventing this part to run.")
 			print(now(), "Did you run ", previous_runmode, "which is required by this step?")
 			print(now(), "Missing file:", f)
 			sys.exit(1)
 		elif not os.path.isfile(f) and runmode == "mltree":
+			os.environ['NOMODELTEST'] = "no"
 			print(now(), "INFO: phylociraptor modeltest was not run, will use specified model for mltree.")
+		elif not os.path.isfile(f) and runmode == "bitree":
+			os.environ['NOMODELTEST'] = "no"
+			print(now(), "INFO: phylociraptor modeltest was not run, which is also not necessary for bitree.")
 		else:
 			if args.debug:
 				print(now(), "DEBUG: File found:", f)
@@ -265,6 +269,8 @@ def execute_command(cmd, verbose, config, isutil=False):
 					yield "\t\t   Parameters: %s\n" % line.split(":")[1].strip()
 				if line.startswith("Nothing to be done"):
 					yield now() + " There is nothing to do. To force a rerun use: -f/--force or -F/--FORCE\n"
+				if line.startswith("ERROR"):
+					yield now() + " " + line
 			else:
 				result = line
 				if result.startswith("Nothing"):
@@ -275,6 +281,8 @@ def execute_command(cmd, verbose, config, isutil=False):
 				#	if len(result.split("")) == 2: # the line with the total number of jobs has two elements
 					if nline <= 30:
 						yield now()+" Total number of tasks for this step: %s\n" % result.split(" ")[-1].strip() 
+				if result.startswith("ERROR"):
+					yield now() + " "  + result
 				elif jobcounts and result == "":
 					jobcounts = False
 				line=""
@@ -302,6 +310,8 @@ def execute_command(cmd, verbose, config, isutil=False):
 					yield "\t\t   Command: %s\n" % line
 				if line.startswith("Nothing to be done"):
 					yield now() + " There is nothing to do. To force a rerun use: -f/--force or -F/--FORCE\n"
+				if line.startswith("ERROR"):
+					yield now() + " " + line
 			else:
 				result = line
 				if result.startswith("Singularity"):
@@ -322,6 +332,8 @@ def execute_command(cmd, verbose, config, isutil=False):
 				if line.startswith("rule"):
 					curr_task += 1
 					yield progressbar(range(njobs),curr_task, "Submitting: ", 100)
+				if line.startswith("ERROR"):
+					yield now() + " " + line
 				line=""
 	else: # serial/local mode
 		if not isutil:
@@ -348,6 +360,8 @@ def execute_command(cmd, verbose, config, isutil=False):
 					yield now() + " There is nothing to do. To force a rerun use: -f/--force or -F/--FORCE\n"
 				if line.startswith("  |"):
 					yield now() + " Progress" + line.strip("\n") + "\r"
+				if line.startswith("ERROR"):
+					yield now() + line
 			else: # this is the quiet mode with progressbar
 				#if check_for_errors(result):
 				#	yield check_for_errors(result)
@@ -369,6 +383,8 @@ def execute_command(cmd, verbose, config, isutil=False):
 					yield now() + " There is nothing to do. To force a rerun use: -f/--force or -F/--FORCE\n"
 				if line.startswith("  |"):
 					yield now() + " Progress" + line.strip("\n") + "\r"
+				if line.startswith("ERROR"):
+					yield now() + line
 				line=""
 
 def get_additional_snakemake_flags(flags, rerun, unlock):

--- a/phylociraptor
+++ b/phylociraptor
@@ -1012,6 +1012,8 @@ elif args.command == "util":
 			hashes["mltree"] = collect_hashes("mltree", parse_config_file(qs_args.configfile), qs_args.configfile, debug=qs_args.debug, wd=os.getcwd())
 			print(now(), "Calculating analysis hashes for speciestree, this may take a few seconds...")
 			hashes["speciestree"] = collect_hashes("speciestree", parse_config_file(qs_args.configfile), qs_args.configfile, debug=qs_args.debug, wd=os.getcwd())	
+			print(now(), "Calculating analysis hashes for bitree, this may take a few seconds...")
+			hashes["bitree"] = collect_hashes("bitree", parse_config_file(qs_args.configfile), qs_args.configfile, debug=qs_args.debug, wd=os.getcwd())	
 			combinations = []
 			#first calculate all possible combinations:
 			for bs in hashes["mltree"]["mltree"]["per"]:
@@ -1028,13 +1030,17 @@ elif args.command == "util":
 					for trimmer in hashes["speciestree"]["speciestree"]["per"][bs][treeprog]["iqtree"]:
 						for aligner in hashes["speciestree"]["speciestree"]["per"][bs][treeprog]["iqtree"][trimmer]:
 							combinations.append("results/phylogeny/" + treeprog + "/bootstrap-cutoff-" + bs + "/" + aligner + "-" + trimmer + "." + hashes["speciestree"]["speciestree"]["per"][bs][treeprog]["iqtree"][trimmer][aligner] + "/species_tree.tre")
-			## TODO: Add logic for bitrees here to get all combinations!!
-			# now check which files are there in the file system:
+			for bs in hashes["bitree"]["bitree"]["per"]:
+				for treeprog in hashes["bitree"]["bitree"]["per"][bs]:
+					for trimmer in hashes["bitree"]["bitree"]["per"][bs][treeprog]["iqtree"]:
+						for aligner in hashes["bitree"]["bitree"]["per"][bs][treeprog]["iqtree"][trimmer]:
+							combinations.append("results/phylogeny/" + treeprog + "/bootstrap-cutoff-" + bs + "/" + aligner + "-" + trimmer + "." + hashes["bitree"]["bitree"]["per"][bs][treeprog]["iqtree"][trimmer][aligner] + "/phylobayes.con.tre")
 			iqtree_trees = glob.glob("results/phylogeny/iqtree/bootstrap-cutoff-*/*/concat.contree")
+			iqtree_unpartitioned_trees = glob.glob("results/phylogeny/iqtree-unpartitioned/bootstrap-cutoff-*/*/concat.contree")
 			raxml_trees =  glob.glob("results/phylogeny/raxml/bootstrap-cutoff-*/*/raxmlng.raxml.support")
 			astral_trees = glob.glob("results/phylogeny/astral/bootstrap-cutoff-*/*/species_tree.tre")
 			bi_trees = glob.glob("results/phylogeny/phylobayes/bootstrap-cutoff-*/*/phylobayes.con.tre")
-			all_trees = iqtree_trees + raxml_trees + astral_trees + bi_trees
+			all_trees = iqtree_trees + iqtree_unpartitioned_trees + raxml_trees + astral_trees + bi_trees
 			all_trees = [tree for tree in all_trees if tree in combinations] #keep only files which are specified in config file.
 			all_trees = ",".join(all_trees)
 		else:

--- a/rules/bitree.smk
+++ b/rules/bitree.smk
@@ -5,8 +5,6 @@ include: "concatenate.smk"
 
 
 ruleorder: read_params_global > read_params_per
-if os.environ["MODELTEST"] == "no":
-	print(now(), "INFO: Since modeltesting was not run previously will try to use only bootstrap cutoff 0.")
 
 #create new hashes for current stage
 hashes = collect_hashes("bitree", config, configfi, wd=os.getcwd())
@@ -45,13 +43,13 @@ rule read_params_per:
 		"""
 rule read_params_global:
 	input:
-		trigger = compare("results/phylogeny/parameters.mltree."+current_hash+".yaml", configfi),
+		trigger = compare("results/phylogeny/parameters.bitree."+current_hash+".yaml", configfi),
 		previous = previous_params_global
 	output:
-		"results/phylogeny/parameters.mltree."+current_hash+".yaml"
+		"results/phylogeny/parameters.bitree."+current_hash+".yaml"
 	shell:
 		"""
-		bin/read_write_yaml.py {input.trigger} {output} seed genetree_filtering,bootstrap_cutoff mltree,method mltree,options mltree,bootstrap
+		bin/read_write_yaml.py {input.trigger} {output} seed genetree_filtering,bootstrap_cutoff bitree,method bitree,options bitree,chains
 		cat {input.previous} >> {output}
 		"""
 

--- a/rules/bitree.smk
+++ b/rules/bitree.smk
@@ -5,15 +5,17 @@ include: "concatenate.smk"
 
 
 ruleorder: read_params_global > read_params_per
+if os.environ["MODELTEST"] == "no":
+	print(now(), "INFO: Since modeltesting was not run previously will try to use only bootstrap cutoff 0.")
+
+#create new hashes for current stage
+hashes = collect_hashes("bitree", config, configfi, wd=os.getcwd())
 
 aligners = get_aligners()		
 trimmers = get_trimmers()		
 tree_methods = get_treemethods()
-bscuts = get_bootstrap_cutoffs()
 chains = get_bichains()
-
-#create new hashes for current stage 
-hashes = collect_hashes("bitree", config, configfi, wd=os.getcwd())
+bscuts = get_bootstrap_cutoffs()
 
 filter_orthology_hash = hashes['filter-orthology']["global"]
 aligner_hashes = hashes['align']["per"]
@@ -22,8 +24,8 @@ modeltest_hashes = hashes['modeltest']["per"]
 tinference_hashes = hashes['bitree']["per"]
 current_hash = hashes['bitree']["global"]
 previous_hash = hashes['modeltest']["global"]
+previous_alitrim_hash = hashes['filter-align']["global"]
 
-print(hashes["modeltest"])
 
 ############ functions specifically for this step
 def compare_bitree(wildcards):
@@ -125,6 +127,9 @@ rule phylobayes:
 
 def pull(wildcards):
 	lis = []
+	if "NOMODELTEST" in os.environ.keys():
+		bscuts = [0]
+	# decide what has been run and modify accordingly
 	for i in config["bitree"]["method"]:
 		for m in config['modeltest']['method']:
 			for a in aligners:

--- a/rules/functions.smk
+++ b/rules/functions.smk
@@ -53,7 +53,7 @@ def get_aligners():
 	elif isinstance(aligners, list):
 		return aligners
 	else:
-		print("phylociraptor filter-align: The alignment methods need to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator. ")
+		print("ERROR in phylociraptor filter-align: The alignment methods need to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator. ")
 		sys.exit(1)
 
 def get_trimmers():
@@ -72,7 +72,7 @@ def get_trimmers():
 	elif isinstance(trimmers, list):
 		return trimmers
 	else:
-		print("phylociraptor filter-align: The trimming methods need to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator. ")
+		print("ERROR in phylociraptor filter-align: The trimming methods need to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator. ")
 		sys.exit(1)
 
 def get_treemethods():
@@ -91,27 +91,38 @@ def get_treemethods():
 	elif isinstance(trees, list):
 		return trees
 	else:
-		print("phylociraptor mltree: The tree methods need to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator. ")
+		print("ERROR in phylociraptor mltree: The tree methods need to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator. ")
 		sys.exit(1)
 
 def get_bootstrap_cutoffs():
 	bscut = config["genetree_filtering"]["bootstrap_cutoff"]
+
+	bscut_list = []
 	if isinstance(bscut, str):
 		if ", " in bscut:
-			return bscut.split(", ")
+			bscut_list = bscut.split(", ")
 		elif " ," in bscut:
-			return bscut.split(" ,")
+			bscut_list = bscut.split(" ,")
 		elif "," in bscut:
-			return bscut.split(",")
+			bscut_list = bscut.split(",")
 		elif " " in bscut:
-			return bscut.split(" ")
+			bscut_list = bscut.split(" ")
 		else:
-			return bscut
+			bscut_list = bscut
 	elif isinstance(bscut, list):
-		return bscut
+		bscut_list = bscut
 	else:
-		print("phylociraptor: The bootstrap cutoffs need to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator. ")
+		print("ERROR in phylociraptor: The bootstrap cutoffs need to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator between values.")
 		sys.exit(1)
+	if "NOMODELTEST" in os.environ.keys(): #check if modeltest was run or not
+		if "0" in bscut_list or 0 in bscut_list:
+			return bscut_list
+		else:
+			print("ERROR in phylociraptor: Bootstrap cutoff 0 needs to be specified in the config file when modeltest has not been run. Will exit now.")
+			sys.exit(1)	
+	else:
+		return bscut_list
+	
 
 def get_genetree_methods():
 	genetrees = config["filtering"]["bootstrap_cutoff"]
@@ -129,7 +140,7 @@ def get_genetree_methods():
 	elif isinstance(genetrees, list):
 		return genetrees
 	else:
-		print("phylociraptor modeltest: The genetree method needs to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator. ")
+		print("ERROR in phylociraptor modeltest: The genetree method needs to be either specified as string or as python list. When this is provided as string use a space( ) or comma (,) as separator. ")
 		sys.exit(1)
 
 def get_bichains():

--- a/rules/mltree.smk
+++ b/rules/mltree.smk
@@ -9,10 +9,6 @@ aligners = get_aligners()
 trimmers = get_trimmers()		
 tree_methods = get_treemethods()
 allbscuts = get_bootstrap_cutoffs()
-print(aligners)
-print(trimmers)
-print(tree_methods)
-print(allbscuts)
 
 #create new hashes for current stage 
 hashes = collect_hashes("mltree", config, configfi, wd=os.getcwd())

--- a/rules/mltree.smk
+++ b/rules/mltree.smk
@@ -8,7 +8,11 @@ ruleorder: read_params_global > read_params_per
 aligners = get_aligners()		
 trimmers = get_trimmers()		
 tree_methods = get_treemethods()
-bscuts = get_bootstrap_cutoffs()
+allbscuts = get_bootstrap_cutoffs()
+print(aligners)
+print(trimmers)
+print(tree_methods)
+print(allbscuts)
 
 #create new hashes for current stage 
 hashes = collect_hashes("mltree", config, configfi, wd=os.getcwd())
@@ -135,7 +139,8 @@ rule prepare_iqtree:
 			models = get_best_models,
 			modelsfile = get_best_models_filename,
 			alidir = get_alignment_dir, 
-			genes = get_input_genes
+			genes = get_input_genes,
+			iqtree_params = config["mltree"]["options"]["iqtree"]
 		shell:
 			"""
 			mkdir {output.algn}
@@ -146,8 +151,22 @@ rule prepare_iqtree:
 			done
 			
 			echo "$(date) - Will create NEXUS partition file with model information now." >> {params.wd}/results/statistics/runlog.txt
-			if [[ -f {params.wd}/{params.models} ]]; then
-				echo "$(date) - 'phylociraptor modeltest' finished successfully before for {wildcards.aligner} and {wildcards.alitrim}. Will run iqtree with best models." >> {params.wd}/results/statistics/runlog.txt
+			# check if -m is in iqtree_params
+
+			
+			if [[ -f {params.wd}/{params.models} ]]; then # modeltest was run
+				if [[ $"{params.iqtree_params}" == *"-m "* ]]; then # model was specified (this overwrites best models from modeltest)
+					model=$(echo "{params.iqtree_params}" | awk '{{ for(i=1;i<=NF;i++) {{ if($i=="-m") {{ if(i < NF) {{ print $(i+1); }}break; }}}}}}')
+					if [[ "$model" == *"MFP"* || "$model" == *"TEST"* || "$model" == *"MERGE"* ]]; then
+						model="None"
+					fi
+					echo "$(date) - 'phylociraptor modeltest' finished successfully before for {wildcards.aligner} and {wildcards.alitrim}, however a model was specified in the config file: $model. Will apply this model to all partitions." >> {params.wd}/results/statistics/runlog.txt
+				else
+					echo "$(date) - 'phylociraptor modeltest' finished successfully before for {wildcards.aligner} and {wildcards.alitrim}. Will run iqtree with best models for each gene/partition." >> {params.wd}/results/statistics/runlog.txt
+					model="None"
+				fi	 
+
+				# write iqtree nexus partition file
 				echo "#nexus" > {output.nexus}
 				echo "begin sets;" >> {output.nexus}
 				i=1
@@ -155,14 +174,41 @@ rule prepare_iqtree:
 					for gene in $(echo "{params.genes}")
 					do
 						cat {params.wd}/{params.models} | grep $gene | awk -v i=$i '{{print "charset part"i" = algn/"$1"_aligned_trimmed.fas:*;"}}' >> {output.nexus}
-						charpart=$charpart$(cat {params.wd}/{params.models} | grep $gene | awk -v i=$i '{{printf($2":part"i", ")}}' | sed 's/\\(.*\\), /\\1, /')
+						if [[ "$model" == "None" ]]; then 
+							charpart=$charpart$(cat {params.wd}/{params.models} | grep $gene | awk -v i=$i '{{printf($2":part"i", ")}}' | sed 's/\\(.*\\), /\\1, /')
+						else
+							charpart=$charpart$(cat {params.wd}/{params.models} | grep $gene | awk -v i=$i -v model=$model '{{printf(model":part"i", ")}}' | sed 's/\\(.*\\), /\\1, /')
+						fi
 						i=$((++i))
 					done
 				echo "charpartition mine = "$charpart";" >> {output.nexus}
 				echo "end;" >> {output.nexus} #concat.nex
-			else
-				echo "$(date) - 'phylociraptor modeltest' was not run before for {wildcards.aligner} and {wildcards.alitrim}. Will run iqtree with a general model." >> {params.wd}/results/statistics/runlog.txt
-				touch {output.nexus}
+
+			else # modeltest was not run.
+				if [[ $"{params.iqtree_params}" == *"-m "* ]]; then
+					model=$(echo "{params.iqtree_params}" | awk '{{ for(i=1;i<=NF;i++) {{ if($i=="-m") {{ if(i < NF) {{ print $(i+1); }}break; }}}}}}')
+					echo "$(date) - 'phylociraptor modeltest' was not run before for {wildcards.aligner} and {wildcards.alitrim}. Will run iqtree with the model specified in the config file for each partition/gene: $model" >> {params.wd}/results/statistics/runlog.txt
+				else
+					echo "$(date) - 'phylociraptor modeltest' was not run before for {wildcards.aligner} and {wildcards.alitrim}. Will run iqtree with -m MFP." >> {params.wd}/results/statistics/runlog.txt
+					model="None"
+				fi	 
+				echo "#nexus" > {output.nexus}
+				echo "begin sets;" >> {output.nexus}
+				i=1
+				charpart=""
+					for gene in $(echo "{params.genes}")
+					do
+						echo "charset part$i = algn/$gene""_aligned_trimmed.fas:*;" >> {output.nexus}
+						charpart="${{charpart}}$model:part$i,"
+						i=$((++i))
+					done
+
+				if [[ "$model" != "None" ]]; then # only write model partition line when a model has been specified.
+					echo "charpartition mine = "$charpart";" >> {output.nexus}
+				fi
+					
+				echo "end;" >> {output.nexus} #concat.nex
+				
 			fi
 				# insert code for specified model here
 			echo "$(date) - nexus file for iqtree written." >> {params.wd}/results/statistics/runlog.txt
@@ -193,30 +239,102 @@ rule iqtree:
 		shell:
 			"""
 			cd results/phylogeny/iqtree/bootstrap-cutoff-{wildcards.bootstrap}/{wildcards.aligner}-{wildcards.alitrim}.{wildcards.hash}/
-			if [[ -s concat.nex ]]; then
+			if grep -q "charpartition" concat.nex; then
 				# file contains model info
-				iqtree -p concat.nex --prefix concat -bb {params.bb} -nt {threads} $(if [[ "{params.seed}" != "None" ]]; then echo "-seed {params.seed}"; fi) {params.additional_params} 2>&1 | tee {params.wd}/{log}
+				iqtree --redo -p concat.nex --prefix concat -bb {params.bb} -nt {threads} $(if [[ "{params.seed}" != "None" ]]; then echo "-seed {params.seed}"; fi) {params.additional_params} 2>&1 | tee {params.wd}/{log}
 				statistics_string="iqtree\t{wildcards.aligner}\t{wildcards.alitrim}\t{params.bb}\t{wildcards.bootstrap}\t$(ls algn | wc -l)\t$(cat concat.contree)"
-			else # file is empty iqtree should rely on the user specifying model(s).
-				echo "Modeltest does not seem to have been run. IQ-Tree will therefore run without the best models and partitioning scheme from phylociraptor modeltest"
-				genes=$(ls algn/*.fas | tr "\n" ",") 
-				iqtree -s $genes --prefix concat -bb {params.bb} -nt {threads} $(if [[ "{params.seed}" != "None" ]]; then echo "-seed {params.seed}"; fi) {params.additional_params} 2>&1 | tee {params.wd}/{log}
+			else # partition file does not contain models, also this means no models have been specified in config file.
+				echo "Modeltest does not seem to have been run and no model has been specified in config file."
+				echo "IQ-Tree will therefore run without the best models and partitioning scheme from phylociraptor modeltest and use -m MFP instead."
+				iqtree --redo -p concat.nex -m MFP --prefix concat -bb {params.bb} -nt {threads} $(if [[ "{params.seed}" != "None" ]]; then echo "-seed {params.seed}"; fi) {params.additional_params} 2>&1 | tee {params.wd}/{log}
 				statistics_string="iqtree\t{wildcards.aligner}\t{wildcards.alitrim}\t{params.bb}\t{wildcards.bootstrap}\t$(ls algn | wc -l)\t$(cat concat.contree)"
 			fi
 			echo -e $statistics_string > {params.wd}/{output.statistics}	
 			touch {params.wd}/{output.checkpoint}
 			"""
 
+rule prepare_iqtree_unpartitioned:
+		input:
+			get_modeltest_checkpoint,
+			get_iqtree_params,
+			algn = rules.concatenate.output.alignment
+		output:
+			algn = directory("results/phylogeny/iqtree-unpartitioned/bootstrap-cutoff-{bootstrap}/{aligner}-{alitrim}.{hash}/algn"),
+			concatalgn = "results/phylogeny/iqtree-unpartitioned/bootstrap-cutoff-{bootstrap}/{aligner}-{alitrim}.{hash}/concat.fas",
+		singularity:
+			containers["iqtree"]
+		params:
+			wd = os.getcwd(),
+			models = get_best_models,
+			modelsfile = get_best_models_filename,
+			alidir = get_alignment_dir, 
+			genes = get_input_genes
+		shell:
+			"""
+			mkdir {output.algn}
+			echo "$(date) - prepare_iqtree_unpartitioned {wildcards.aligner}-{wildcards.alitrim}: Will use bootstrap cutoff ({wildcards.bootstrap})" >> {params.wd}/results/statistics/runlog.txt
+			echo "$(date) - prepare_iqtree_unpartitioned: Will not consider partitioning scheme for {wildcards.aligner} and {wildcards.alitrim}." >> {params.wd}/results/statistics/runlog.txt
+			cp {input.algn} {output.concatalgn}
+			# insert code for specified model here
+			echo "$(date) - concat.fas file for iqtree-unpartitioned written." >> {params.wd}/results/statistics/runlog.txt
+			"""
+
+rule iqtree_unpartitioned:
+		input:
+			rules.prepare_iqtree_unpartitioned.output
+		output:
+			checkpoint = "results/checkpoints/iqtree-unpartitioned_{aligner}_{alitrim}_{bootstrap}.{hash}.done",
+			statistics = "results/statistics/mltree/mltree_iqtree-unpartitioned_{aligner}_{alitrim}_{bootstrap}_statistics.{hash}.txt"
+		benchmark:
+			"results/statistics/benchmarks/tree/iqtreei-unpartitioned_{aligner}_{alitrim}_{bootstrap}.{hash}.txt"
+		singularity:
+			containers["iqtree"]
+		params:
+			wd = os.getcwd(),
+			nt = "AUTO",
+			bb = config["mltree"]["bootstrap"]["iqtree-unpartitioned"],
+			additional_params = config["mltree"]["options"]["iqtree-unpartitioned"],
+			seed=config["seed"],
+			genes = get_input_genes
+		threads:
+			config["mltree"]["threads"]["iqtree-unpartitioned"]
+		log:
+			"log/mltree/iqtree/iqtree-unpartitioned-{aligner}-{alitrim}-{bootstrap}.{hash}.txt"
+		shell:
+			"""
+			cd results/phylogeny/iqtree-unpartitioned/bootstrap-cutoff-{wildcards.bootstrap}/{wildcards.aligner}-{wildcards.alitrim}.{wildcards.hash}/
+
+			echo "This analysis will be unpartitioned. IQ-Tree will run without the best models and partitioning scheme from phylociraptor modeltest."
+			echo "Instead this will use modelsetting specified in config file: {params.additional_params}."
+			if [[ $"{params.additional_params}" == *"-m "* ]]; then
+				echo "Will use spcified model from config file"
+				iqtree -s concat.fas {params.additional_params} --prefix concat -bb {params.bb} -nt {threads} --redo $(if [[ "{params.seed}" != "None" ]]; then echo "-seed {params.seed}"; fi) 2>&1 | tee {params.wd}/{log}
+			else
+				echo "No model has been specified in config file. Will use default: -m MFP"
+				iqtree -s concat.fas --prefix concat -bb {params.bb} -nt {threads} $(if [[ "{params.seed}" != "None" ]]; then echo "-seed {params.seed}"; fi) -m MFP {params.additional_params} 2>&1 | tee {params.wd}/{log}
+			fi
+			statistics_string="iqtree\t{wildcards.aligner}\t{wildcards.alitrim}\t{params.bb}\t{wildcards.bootstrap}\t$(ls algn | wc -l)\t$(cat concat.contree)"
+		
+			echo -e $statistics_string > {params.wd}/{output.statistics}	
+			touch {params.wd}/{output.checkpoint}
+			"""
 
 def pull(wildcards):
 	lis = []
+	bscuts = allbscuts
+	if "NOMODELTEST" in os.environ.keys(): #modeltest was not run!
+		bscuts = [0]
 	for i in tree_methods:
 		for m in config['modeltest']['method']:
 			for a in aligners:
 				for t in trimmers:
 					for b in bscuts:
-						lis.append("results/checkpoints/"+i+"_"+a+"_"+t+"_"+str(b)+"."+tinference_hashes[str(b)][i][m][t][a]+".done")
-						lis.append("results/phylogeny/" + i + "/bootstrap-cutoff-"+str(b)+"/parameters.mltree."+i+"-"+a+"-"+t+"."+tinference_hashes[str(b)][i][m][t][a]+".yaml")
+						if "NOMODELTEST" in os.environ.keys(): # modeltest was not run!
+							lis.append("results/checkpoints/"+i+"_"+a+"_"+t+"_"+str(b)+"."+tinference_hashes[str(b)][i][m][t][a]+".done")
+							lis.append("results/phylogeny/" + i + "/bootstrap-cutoff-"+str(b)+"/parameters.mltree."+i+"-"+a+"-"+t+"."+tinference_hashes[str(b)][i][m][t][a]+".yaml")
+						else: # modeltest was run.
+							lis.append("results/checkpoints/"+i+"_"+a+"_"+t+"_"+str(b)+"."+tinference_hashes[str(b)][i][m][t][a]+".done")
+							lis.append("results/phylogeny/" + i + "/bootstrap-cutoff-"+str(b)+"/parameters.mltree."+i+"-"+a+"-"+t+"."+tinference_hashes[str(b)][i][m][t][a]+".yaml")
 	return lis
 	
 


### PR DESCRIPTION
The logic for performing unpartitioned analyses has been thoroughly reworked with this PR.

- Now unpartitioned analyses have their own method in mltree: iqtree-unpartitioned.
- They require for bs-cutoff 0 to be set. This fixes an older problem where unpartitioned analyses would be repeated for each bootstrap cutoff.
- Unpartitioned analyses can now be performed also after modeltest was run. In this case only the genes passing the bs-cutoff value will be used.
- In Unpartitioned analyses: MFP is the default now when no model is specified. A specified model will be applied to the whole concatenated alignment.
- In partitioned analyses: MFP is the default now when no model is specified. This could mean that partitions (individual genes) could be merged. If a model is specified it will be applied to all partitions individually.
- Utilities and report have been modified to accomodate these changes as well.
- The logic with the bs-cutoff also applies to bitree now.
-  Add documentation about this.

